### PR TITLE
Corrected module name to import MNIST

### DIFF
--- a/mnist_example.py
+++ b/mnist_example.py
@@ -6,7 +6,7 @@ import argparse
 import torchquantum as tq
 import torchquantum.functional as tqf
 
-from examples.core.datasets import MNIST
+from torchquantum.datasets import MNIST
 from torch.optim.lr_scheduler import CosineAnnealingLR
 
 


### PR DESCRIPTION
Corrected `from examples.core.datasets import MNIST` to `from torchquantum.datasets import MNIST`