### PR TITLE
fix a minor bug in quantumnat.py

### DIFF
--- a/examples/quantumnat/quantumnat.py
+++ b/examples/quantumnat/quantumnat.py
@@ -84,6 +84,7 @@ class QFCModel(tq.QuantumModule):
         self.measure = tq.MeasureAll(tq.PauliZ)
 
     def forward(self, x, use_qiskit=False):
+        self.q_device.reset_states(x.shape[0])
         bsz = x.shape[0]
         x = F.avg_pool2d(x, 6).view(bsz, 16)
 


### PR DESCRIPTION
Hi Hanrui,

In the forward function, need to reset_states(bsz) for self.q_device. If not, the program will run into the following error:
```
RuntimeError: Expected size for first two dimensions of batch2 tensor to be: [256, 2] but got: [1, 2]
```

Thanks,
Caitao