### PR TITLE
Update deprecated `torch.range` and `torch.outer`

### DIFF
--- a/examples/gradient_pruning/q_models.py
+++ b/examples/gradient_pruning/q_models.py
@@ -130,7 +130,7 @@ class QMultiFCModel0(tq.QuantumModule):
                 node.shift_this_step[idx] = True
             elif self.pruning_method == "perlayer_pruning":
                 node.shift_this_step[:] = False
-                idxs = torch.range(0, self.n_params - 1, dtype=int).view(
+                idxs = torch.arange(0, self.n_params, dtype=int).view(
                     self.n_qubits, self.n_layers
                 )
                 sampled_colums = self.colums
@@ -140,7 +140,7 @@ class QMultiFCModel0(tq.QuantumModule):
                 self.colums %= self.n_layers
             elif self.pruning_method == "perqubit_pruning":
                 node.shift_this_step[:] = False
-                idxs = torch.range(0, self.n_params - 1, dtype=int).view(
+                idxs = torch.arange(0, self.n_params, dtype=int).view(
                     self.n_qubits, self.n_layers
                 )
                 sampled_rows = self.rows

--- a/torchquantum/pulse/utils.py
+++ b/torchquantum/pulse/utils.py
@@ -40,7 +40,7 @@ def InitialState(n_qubit = 1, state = [0]):
 
 def InitialDensity(n_qubit = 1, state = [0]):
     initial_state = InitialState(n_qubit, state)
-    initial_density = torch.ger(initial_state, torch.conj(initial_state))
+    initial_density = torch.outer(initial_state, torch.conj(initial_state))
     return initial_density
 
 def H_2q_example(pulse, dt):


### PR DESCRIPTION
`torch.range` and `torch.outer` are deprecated and will be removed in a future PyTorch release.

Fixed with TorchFix https://github.com/pytorch/test-infra/tree/main/tools/torchfix