### PR TITLE
Update module path to qiskit_unitary_gate

### DIFF
--- a/torchquantum/plugin/qiskit/qiskit_plugin.py
+++ b/torchquantum/plugin/qiskit/qiskit_plugin.py
@@ -274,7 +274,7 @@ def append_fixed_gate(circ, func, params, wires, inverse):
         circ.swap(*wires)
     elif func == "sswap":
         # square root of swap
-        from torchquantum.plugin.qiskit_unitary_gate import UnitaryGate
+        from torchquantum.plugin.qiskit.qiskit_unitary_gate import UnitaryGate
 
         mat = mat_dict["sswap"].detach().cpu().numpy()
         mat = switch_little_big_endian_matrix(mat)
@@ -308,7 +308,7 @@ def append_fixed_gate(circ, func, params, wires, inverse):
         or func == "qubitunitaryfast"
         or func == "qubitunitarystrict"
     ):
-        from torchquantum.plugin.qiskit_unitary_gate import UnitaryGate
+        from torchquantum.plugin.qiskit.qiskit_unitary_gate import UnitaryGate
 
         mat = np.array(params)
         mat = switch_little_big_endian_matrix(mat)
@@ -512,7 +512,7 @@ def tq2qiskit(
             circ.swap(*module.wires)
         elif module.name == "SSWAP":
             # square root of swap
-            from torchquantum.plugin.qiskit_unitary_gate import UnitaryGate
+            from torchquantum.plugin.qiskit.qiskit_unitary_gate import UnitaryGate
 
             mat = module.matrix.data.cpu().numpy()
             mat = switch_little_big_endian_matrix(mat)
@@ -547,7 +547,7 @@ def tq2qiskit(
             or module.name == "TrainableUnitary"
             or module.name == "TrainableUnitaryStrict"
         ):
-            from torchquantum.plugin.qiskit_unitary_gate import UnitaryGate
+            from torchquantum.plugin.qiskit.qiskit_unitary_gate import UnitaryGate
 
             mat = module.params[0].data.cpu().numpy()
             mat = switch_little_big_endian_matrix(mat)


### PR DESCRIPTION
I saw after the directory restructuring that some of my code was failing when trying to output the circuit qasm. This was caused by the line in `qiskit_plugins.py` which attempts to import as: `from torchquantum.plugin.qiskit_unitary_gate import UnitaryGate`

I checked the `__init__.py` files and it looked like this import should be okay, but for some reason it was still failing to find the `qiskit_unitary_gate` module. I made a simple fix which was just to include the `qiskit` directory in the import statement, but I'm still not sure why the `__init__.py` was failing to find it in the first place.

But hopefully this fix will work for now.