### PR TITLE
GlobalR/GlobalRX/GlobalRY Gates

### DIFF
--- a/test/layers/test_rotgate.py
+++ b/test/layers/test_rotgate.py
@@ -7,13 +7,14 @@ from torchquantum.util import (
     find_global_phase,
 )
 
-from qiskit.circuit.library import GR, GRX, GRY
+from qiskit.circuit.library import GR, GRX, GRY, GRZ
 import numpy as np
 
 all_pairs = [
-    # {"qiskit": GR, "tq": tq.layer.GlobalR, "params": 2},
+    {"qiskit": GR, "tq": tq.layer.GlobalR, "params": 2},
     {"qiskit": GRX, "tq": tq.layer.GlobalRX, "params": 1},
     {"qiskit": GRY, "tq": tq.layer.GlobalRY, "params": 1},
+    {"qiskit": GRZ, "tq": tq.layer.GlobalRZ, "params": 1},
 ]
 
 ITERATIONS = 10

--- a/test/layers/test_rotgate.py
+++ b/test/layers/test_rotgate.py
@@ -1,0 +1,54 @@
+import torchquantum as tq
+import qiskit
+from qiskit import Aer, execute
+
+from torchquantum.util import (
+    switch_little_big_endian_matrix,
+    find_global_phase,
+)
+
+from qiskit.circuit.library import GR, GRX, GRY
+import numpy as np
+
+all_pairs = [
+    # {"qiskit": GR, "tq": tq.layer.GlobalR, "params": 2},
+    {"qiskit": GRX, "tq": tq.layer.GlobalRX, "params": 1},
+    {"qiskit": GRY, "tq": tq.layer.GlobalRY, "params": 1},
+]
+
+ITERATIONS = 10
+
+# test each pair
+for pair in all_pairs:
+    # test 2-5 wires
+    for num_wires in range(2, 5):
+        # try multiple random parameters
+        for _ in range(ITERATIONS):
+            # generate random parameters
+            params = [
+                np.random.uniform(-2 * np.pi, 2 * np.pi) for _ in range(pair["params"])
+            ]
+
+            # create the qiskit circuit
+            qiskit_circuit = pair["qiskit"](num_wires, *params)
+
+            # get the unitary from qiskit
+            backend = Aer.get_backend("unitary_simulator")
+            result = execute(qiskit_circuit, backend).result()
+            unitary_qiskit = result.get_unitary(qiskit_circuit)
+
+            # create tq circuit
+            qdev = tq.QuantumDevice(num_wires)
+            tq_circuit = pair["tq"](num_wires, *params)
+            tq_circuit(qdev)
+
+            # get the unitary from tq
+            unitary_tq = tq_circuit.get_unitary(qdev)
+            unitary_tq = switch_little_big_endian_matrix(unitary_tq.data.numpy())
+
+            # phase?
+            phase = find_global_phase(unitary_tq, unitary_qiskit, 1e-4)
+
+            assert np.allclose(
+                unitary_tq * phase, unitary_qiskit, atol=1e-6
+            ), f"{pair} not equal with {params=}!"

--- a/torchquantum/layer/__init__.py
+++ b/torchquantum/layer/__init__.py
@@ -24,3 +24,4 @@ SOFTWARE.
 
 from .layers import *
 from .nlocal import *
+from .general import *

--- a/torchquantum/layer/general.py
+++ b/torchquantum/layer/general.py
@@ -1,0 +1,88 @@
+"""
+MIT License
+
+Copyright (c) 2020-present TorchQuantum Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+import torch
+import torchquantum as tq
+from torchquantum.layer.layers import (
+    LayerTemplate0,
+    Op1QAllLayer,
+    Op2QAllLayer,
+    RandomOp1All,
+)
+
+__all__ = [
+    "GlobalR",
+    "GlobalRX",
+    "GlobalRY",
+    "GlobalRZ",
+]
+
+
+class GlobalR(tq.QuantumModule):
+    """Layer Template for a Global R General Gate"""
+
+    def __init__(
+        self,
+        n_wires: int = 0,
+        theta: float = 0,
+        phi: float = 0,
+    ):
+        """Create the layer"""
+        super().__init__()
+        self.ops_all = tq.QuantumModuleList()
+        self.n_wires = n_wires
+        self.ops_list = [
+            {"name": "rot", "params": [phi, theta, 0], "wires": k}
+            for k in range(self.n_wires)
+        ]
+
+    @tq.static_support
+    def forward(self, q_device):
+        qmodule = tq.QuantumModule.from_op_history(self.ops_list)
+        qmodule(q_device)
+
+
+class GlobalRX(GlobalR):
+    """Layer Template for a Global RX General Gate"""
+
+    def __init__(
+        self,
+        n_wires: int = 0,
+        theta: float = 0,
+    ):
+        """Create the layer"""
+        super().__init__(n_wires, theta, phi=0)
+
+
+class GlobalRY(GlobalR):
+    """Layer Template for a Global RY General Gate"""
+
+    def __init__(
+        self,
+        n_wires: int = 0,
+        theta: float = 0,
+    ):
+        """Create the layer"""
+        super().__init__(n_wires, theta, phi=torch.pi / 2)

--- a/torchquantum/layer/general.py
+++ b/torchquantum/layer/general.py
@@ -31,12 +31,12 @@ from torchquantum.layer.layers import (
     Op2QAllLayer,
     RandomOp1All,
 )
+from torchquantum.operator.operators import R
 
 __all__ = [
     "GlobalR",
     "GlobalRX",
     "GlobalRY",
-    "GlobalRZ",
 ]
 
 
@@ -51,17 +51,13 @@ class GlobalR(tq.QuantumModule):
     ):
         """Create the layer"""
         super().__init__()
-        self.ops_all = tq.QuantumModuleList()
         self.n_wires = n_wires
-        self.ops_list = [
-            {"name": "rot", "params": [phi, theta, 0], "wires": k}
-            for k in range(self.n_wires)
-        ]
+        self.params = torch.tensor([[theta, phi]])
 
     @tq.static_support
-    def forward(self, q_device):
-        qmodule = tq.QuantumModule.from_op_history(self.ops_list)
-        qmodule(q_device)
+    def forward(self, q_device, x=None):
+        for k in range(self.n_wires):
+            R()(q_device, wires=k, params=self.params)
 
 
 class GlobalRX(GlobalR):

--- a/torchquantum/layer/general.py
+++ b/torchquantum/layer/general.py
@@ -36,6 +36,7 @@ __all__ = [
     "GlobalR",
     "GlobalRX",
     "GlobalRY",
+    "GlobalRZ",
 ]
 
 
@@ -81,3 +82,23 @@ class GlobalRY(GlobalR):
     ):
         """Create the layer"""
         super().__init__(n_wires, theta, phi=torch.pi / 2)
+
+class GlobalRZ(tq.QuantumModule):
+    """Layer Template for a Global RZ General Gate"""
+
+    def __init__(
+        self,
+        n_wires: int = 0,
+        phi: float = 0,
+    ):
+        """Create the layer"""
+        super().__init__()
+        self.n_wires = n_wires
+        self.params = torch.tensor([[phi]])
+
+    @tq.static_support
+    def forward(self, q_device, x=None):
+        for k in range(self.n_wires):
+            tq.RZ()(q_device, wires=k, params=self.params)
+
+

--- a/torchquantum/layer/general.py
+++ b/torchquantum/layer/general.py
@@ -31,7 +31,6 @@ from torchquantum.layer.layers import (
     Op2QAllLayer,
     RandomOp1All,
 )
-from torchquantum.operator.operators import R
 
 __all__ = [
     "GlobalR",
@@ -57,7 +56,7 @@ class GlobalR(tq.QuantumModule):
     @tq.static_support
     def forward(self, q_device, x=None):
         for k in range(self.n_wires):
-            R()(q_device, wires=k, params=self.params)
+            tq.R()(q_device, wires=k, params=self.params)
 
 
 class GlobalRX(GlobalR):


### PR DESCRIPTION
Adding support for the GlobalR/RX/RY General Gates as layers, similar to the [GlobalR Gates](https://qiskit.org/documentation/_modules/qiskit/circuit/library/generalized_gates/gr.html) from Qiskit