### PR TITLE
Bugfix: Error when uploading some circuits to TorchQuantum

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
     <a href="https://join.slack.com/t/torchquantum/shared_invite/zt-1ghuf283a-OtP4mCPJREd~367VX~TaQQ">
         <img alt="Chat @ Slack" src="https://img.shields.io/badge/slack-chat-2eb67d.svg?logo=slack">
     </a>
+    <a href="https://discord.gg/VTHZAB5E">
+        <img alt="Chat @ Discord" src="https://img.shields.io/badge/contact-me-blue?logo=discord&logoColor=white">
+    </a>
     <a href="https://qmlsys.hanruiwang.me">
         <img alt="Forum" src="https://img.shields.io/discourse/status?server=https%3A%2F%2Fqmlsys.hanruiwang.me%2F">
     </a>

--- a/torchquantum/plugin/qiskit/qiskit_plugin.py
+++ b/torchquantum/plugin/qiskit/qiskit_plugin.py
@@ -682,7 +682,10 @@ def qiskit2tq_Operator(circ: QuantumCircuit):
         try:
             p2v_orig = circ._layout.final_layout.get_physical_bits().copy()
         except:
-            p2v_orig = circ._layout.get_physical_bits().copy()
+            try:
+                p2v_orig = circ._layout.get_physical_bits().copy()
+            except:
+                p2v_orig = circ._layout.initial_layout.get_physical_bits().copy()
         p2v = {}
         for p, v in p2v_orig.items():
             if v.register.name == "q":


### PR DESCRIPTION
Fixes bug with importing transpiled circuits which are mapped trivially (resulting in a set initial_layout but a null final_layout). This will come up often on circuits that are transpiled with optimization_level=0, though this can happen on any level of optimization if the trivial layout happens to be optimal.

Code to replicate the bug:
`
from torchquantum.plugins import qiskit2tq

from qiskit.circuit.library import RealAmplitudes
from qiskit.compiler import transpile

from qiskit.providers.fake_provider import FakeGuadalupe

backend = FakeGuadalupe()

ansatz = RealAmplitudes(2, reps=1)
ansatz = transpile(ansatz, backend, optimization_level=0)

params = [0]*len(ansatz.parameters)
ansatz = ansatz.bind_parameters(params)

tq_layer = qiskit2tq(ansatz)
`