### PR TITLE
Adding Entangle Layers

### DIFF
--- a/torchquantum/layer/layers.py
+++ b/torchquantum/layer/layers.py
@@ -56,6 +56,7 @@ __all__ = [
     "EntanglePairwise",
     "EntangleFull",
     "EntangleCircular",
+    "EntanglementLayer",
 ]
 
 
@@ -1778,6 +1779,59 @@ class EntanglePairwise(tq.QuantumModule):
                     wires.reverse()
                 self.ops_all[k](q_device, wires=wires)
                 k += 1
+
+
+class EntanglementLayer(tq.QuantumModule):
+    """
+    Quantum layer applying a specified two-qubit entanglement type to all qubits. The entanglement types include full, linear, pairwise, and circular.
+
+    Args:
+        op (tq.Operator): Two-qubit operation to be applied.
+        n_wires (int): Number of wires in the quantum device.
+        entanglement_type (str): Type of entanglement from ["full", "linear", "pairwise", "circular"]
+        has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
+        trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
+        wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
+        jump (int, optional): Number of positions to jump between adjacent pairs of wires. Defaults to 1.
+        circular (bool, optional): Flag indicating if the pattern should be circular. Defaults to False.
+
+    """
+
+    def __init__(
+        self,
+        op,
+        n_wires: int,
+        entanglement_type: str,
+        has_params=False,
+        trainable=False,
+        wire_reverse=False,
+    ):
+        super().__init__()
+
+        entanglement_to_class = {
+            "full": EntangleFull,
+            "linear": EntangleLinear,
+            "pairwise": EntanglePairwise,
+            "circular": EntangleCircular,
+        }
+
+        self.entanglement_class = entanglement_to_class.get(entanglement_type, None)
+
+        assert (
+            self.entanglement_class is not None
+        ), f"invalid entanglement type {entanglement_type}"
+
+        self.entanglement_class.__init__(
+            op=op,
+            n_wires=n_wires,
+            has_params=has_params,
+            trainable=trainable,
+            wire_reverse=wire_reverse,
+        )
+
+    @tq.static_support
+    def forward(self, q_device):
+        self.entanglement_class.forward(q_device)
 
 
 layer_name_dict = {

--- a/torchquantum/layer/layers.py
+++ b/torchquantum/layer/layers.py
@@ -62,10 +62,11 @@ __all__ = [
 class QuantumModuleFromOps(tq.QuantumModule):
     """Initializes a QuantumModuleFromOps instance.
 
-            Args:
-                ops (List[tq.Operation]): List of quantum operations.
+    Args:
+        ops (List[tq.Operation]): List of quantum operations.
 
-            """
+    """
+
     def __init__(self, ops):
         super().__init__()
         self.ops = tq.QuantumModuleList(ops)
@@ -74,13 +75,13 @@ class QuantumModuleFromOps(tq.QuantumModule):
     def forward(self, q_device: tq.QuantumDevice):
         """Performs the forward pass of the quantum module.
 
-               Args:
-                   q_device (tq.QuantumDevice): Quantum device to apply the operations on.
+        Args:
+            q_device (tq.QuantumDevice): Quantum device to apply the operations on.
 
-               Returns:
-                   None
+        Returns:
+            None
 
-               """
+        """
         self.q_device = q_device
         for op in self.ops:
             op(q_device)
@@ -115,18 +116,19 @@ class TrainableOpAll(tq.QuantumModule):
 
 class ClassicalInOpAll(tq.QuantumModule):
     """
-      Quantum module that applies the same quantum operation to all wires of a quantum device,
-      where the parameters of the operation are obtained from a classical input.
+    Quantum module that applies the same quantum operation to all wires of a quantum device,
+    where the parameters of the operation are obtained from a classical input.
 
-      Args:
-          n_gate (int): Number of gates.
-          op (tq.Operator): Quantum operation to be applied.
+    Args:
+        n_gate (int): Number of gates.
+        op (tq.Operator): Quantum operation to be applied.
 
-      Attributes:
-          n_gate (int): Number of gates.
-          gate_all (nn.ModuleList): List of quantum operations.
+    Attributes:
+        n_gate (int): Number of gates.
+        gate_all (nn.ModuleList): List of quantum operations.
 
-      """
+    """
+
     def __init__(self, n_gate: int, op: tq.Operator):
         super().__init__()
         self.n_gate = n_gate
@@ -137,19 +139,19 @@ class ClassicalInOpAll(tq.QuantumModule):
     @tq.static_support
     def forward(self, q_device: tq.QuantumDevice, x):
         """
-               Performs the forward pass of the classical input quantum operation module.
+        Performs the forward pass of the classical input quantum operation module.
 
-               Args:
-                   q_device (tq.QuantumDevice): Quantum device to apply the operations on.
-                   x (torch.Tensor): Classical input of shape (batch_size, n_gate).
+        Args:
+            q_device (tq.QuantumDevice): Quantum device to apply the operations on.
+            x (torch.Tensor): Classical input of shape (batch_size, n_gate).
 
-               Returns:
-                   None
+        Returns:
+            None
 
-               Raises:
-                   AssertionError: If the number of gates is different from the number of wires in the device.
+        Raises:
+            AssertionError: If the number of gates is different from the number of wires in the device.
 
-               """
+        """
         # rx on all wires, assert the number of gate is the same as the number
         # of wires in the device.
         assert self.n_gate == q_device.n_wires, (
@@ -163,17 +165,18 @@ class ClassicalInOpAll(tq.QuantumModule):
 
 class FixedOpAll(tq.QuantumModule):
     """
-       Quantum module that applies the same fixed quantum operation to all wires of a quantum device.
+    Quantum module that applies the same fixed quantum operation to all wires of a quantum device.
 
-       Args:
-           n_gate (int): Number of gates.
-           op (tq.Operator): Quantum operation to be applied.
+    Args:
+        n_gate (int): Number of gates.
+        op (tq.Operator): Quantum operation to be applied.
 
-       Attributes:
-           n_gate (int): Number of gates.
-           gate_all (nn.ModuleList): List of quantum operations.
+    Attributes:
+        n_gate (int): Number of gates.
+        gate_all (nn.ModuleList): List of quantum operations.
 
-       """
+    """
+
     def __init__(self, n_gate: int, op: tq.Operator):
         super().__init__()
         self.n_gate = n_gate
@@ -184,18 +187,18 @@ class FixedOpAll(tq.QuantumModule):
     @tq.static_support
     def forward(self, q_device: tq.QuantumDevice):
         """
-                Performs the forward pass of the fixed quantum operation module.
+        Performs the forward pass of the fixed quantum operation module.
 
-                Args:
-                    q_device (tq.QuantumDevice): Quantum device to apply the operations on.
+        Args:
+            q_device (tq.QuantumDevice): Quantum device to apply the operations on.
 
-                Returns:
-                    None
+        Returns:
+            None
 
-                Raises:
-                    AssertionError: If the number of gates is different from the number of wires in the device.
+        Raises:
+            AssertionError: If the number of gates is different from the number of wires in the device.
 
-                """
+        """
         # rx on all wires, assert the number of gate is the same as the number
         # of wires in the device.
         assert self.n_gate == q_device.n_wires, (
@@ -209,17 +212,18 @@ class FixedOpAll(tq.QuantumModule):
 
 class TwoQAll(tq.QuantumModule):
     """
-        Quantum module that applies a two-qubit quantum operation to adjacent pairs of wires in a quantum device.
+    Quantum module that applies a two-qubit quantum operation to adjacent pairs of wires in a quantum device.
 
-        Args:
-            n_gate (int): Number of adjacent pairs of wires.
-            op (tq.Operator): Two-qubit quantum operation to be applied.
+    Args:
+        n_gate (int): Number of adjacent pairs of wires.
+        op (tq.Operator): Two-qubit quantum operation to be applied.
 
-        Attributes:
-            n_gate (int): Number of adjacent pairs of wires.
-            op (tq.Operator): Two-qubit quantum operation.
+    Attributes:
+        n_gate (int): Number of adjacent pairs of wires.
+        op (tq.Operator): Two-qubit quantum operation.
 
-        """
+    """
+
     def __init__(self, n_gate: int, op: tq.Operator):
         super().__init__()
         self.n_gate = n_gate
@@ -274,28 +278,29 @@ class RandomOp1All(tq.QuantumModule):
 
 class RandomLayer(tq.QuantumModule):
     """
-        Quantum module that represents a random layer of quantum operations applied to specified wires.
+    Quantum module that represents a random layer of quantum operations applied to specified wires.
 
-        Args:
-            wires (int or Iterable[int]): Indices of the wires the operations are applied to.
-            n_ops (int): Number of random operations in the layer.
-            n_params (int): Number of parameters for each random operation.
-            op_ratios (list or float): Ratios determining the relative frequencies of different operation types.
-            op_types (tuple or tq.Operator): Types of random operations to be included in the layer.
-            seed (int): Seed for random number generation.
-            qiskit_compatible (bool): Flag indicating whether the layer should be compatible with Qiskit.
+    Args:
+        wires (int or Iterable[int]): Indices of the wires the operations are applied to.
+        n_ops (int): Number of random operations in the layer.
+        n_params (int): Number of parameters for each random operation.
+        op_ratios (list or float): Ratios determining the relative frequencies of different operation types.
+        op_types (tuple or tq.Operator): Types of random operations to be included in the layer.
+        seed (int): Seed for random number generation.
+        qiskit_compatible (bool): Flag indicating whether the layer should be compatible with Qiskit.
 
-        Attributes:
-            n_ops (int): Number of random operations in the layer.
-            n_params (int): Number of parameters for each random operation.
-            wires (list): Indices of the wires the operations are applied to.
-            n_wires (int): Number of wires.
-            op_types (list): Types of random operations included in the layer.
-            op_ratios (numpy.array): Ratios determining the relative frequencies of different operation types.
-            seed (int): Seed for random number generation.
-            op_list (tq.QuantumModuleList): List of random operations in the layer.
+    Attributes:
+        n_ops (int): Number of random operations in the layer.
+        n_params (int): Number of parameters for each random operation.
+        wires (list): Indices of the wires the operations are applied to.
+        n_wires (int): Number of wires.
+        op_types (list): Types of random operations included in the layer.
+        op_ratios (numpy.array): Ratios determining the relative frequencies of different operation types.
+        seed (int): Seed for random number generation.
+        op_list (tq.QuantumModuleList): List of random operations in the layer.
 
-        """
+    """
+
     def __init__(
         self,
         wires,
@@ -346,15 +351,15 @@ class RandomLayer(tq.QuantumModule):
 
     def rebuild_random_layer_from_op_list(self, n_ops_in, wires_in, op_list_in):
         """
-           Rebuilds a random layer from the given operation list.
-           This method is used for loading a random layer from a checkpoint.
+        Rebuilds a random layer from the given operation list.
+        This method is used for loading a random layer from a checkpoint.
 
-           Args:
-               n_ops_in (int): Number of operations in the layer.
-               wires_in (list): Indices of the wires the operations are applied to.
-               op_list_in (list): List of operations in the layer.
+        Args:
+            n_ops_in (int): Number of operations in the layer.
+            wires_in (list): Indices of the wires the operations are applied to.
+            op_list_in (list): List of operations in the layer.
 
-           """
+        """
 
         self.n_ops = n_ops_in
         self.wires = wires_in
@@ -425,20 +430,21 @@ class RandomLayer(tq.QuantumModule):
 
 class RandomLayerAllTypes(RandomLayer):
     """
-       Random layer with a wide range of quantum gate types.
+    Random layer with a wide range of quantum gate types.
 
-       This class extends the `RandomLayer` class to include a variety of quantum gate types as options for the random layer.
+    This class extends the `RandomLayer` class to include a variety of quantum gate types as options for the random layer.
 
-       Args:
-           wires (int or list): Indices of the wires the operations are applied to.
-           n_ops (int): Number of operations in the layer.
-           n_params (int): Number of parameters for each operation.
-           op_ratios (list): Ratios for selecting different types of operations.
-           op_types (tuple): Types of operations to include in the layer.
-           seed (int): Seed for the random number generator.
-           qiskit_compatible (bool): Flag indicating whether the layer should be Qiskit-compatible.
+    Args:
+        wires (int or list): Indices of the wires the operations are applied to.
+        n_ops (int): Number of operations in the layer.
+        n_params (int): Number of parameters for each operation.
+        op_ratios (list): Ratios for selecting different types of operations.
+        op_types (tuple): Types of operations to include in the layer.
+        seed (int): Seed for the random number generator.
+        qiskit_compatible (bool): Flag indicating whether the layer should be Qiskit-compatible.
 
-       """
+    """
+
     def __init__(
         self,
         wires,
@@ -493,14 +499,15 @@ class RandomLayerAllTypes(RandomLayer):
 
 class SimpleQLayer(tq.QuantumModule):
     """
-       Simple quantum layer consisting of three parameterized gates applied to specific wires.
+    Simple quantum layer consisting of three parameterized gates applied to specific wires.
 
-       This class represents a simple quantum layer with three parameterized gates: RX, RY, and RZ. The gates are applied to specific wires in the quantum device.
+    This class represents a simple quantum layer with three parameterized gates: RX, RY, and RZ. The gates are applied to specific wires in the quantum device.
 
-       Args:
-           n_wires (int): Number of wires in the quantum device.
+    Args:
+        n_wires (int): Number of wires in the quantum device.
 
-       """
+    """
+
     def __init__(self, n_wires):
         super().__init__()
         self.n_wires = n_wires
@@ -520,14 +527,15 @@ class SimpleQLayer(tq.QuantumModule):
 
 class CXLayer(tq.QuantumModule):
     """
-        Quantum layer with a controlled-X (CX) gate applied to two specified wires.
+    Quantum layer with a controlled-X (CX) gate applied to two specified wires.
 
-        This class represents a quantum layer with a controlled-X (CX) gate applied to two specified wires in the quantum device.
+    This class represents a quantum layer with a controlled-X (CX) gate applied to two specified wires in the quantum device.
 
-        Args:
-            n_wires (int): Number of wires in the quantum device.
+    Args:
+        n_wires (int): Number of wires in the quantum device.
 
-        """
+    """
+
     def __init__(self, n_wires):
         super().__init__()
         self.n_wires = n_wires
@@ -540,14 +548,15 @@ class CXLayer(tq.QuantumModule):
 
 class CXCXCXLayer(tq.QuantumModule):
     """
-       Quantum layer with a sequence of CX gates applied to three specified wires.
+    Quantum layer with a sequence of CX gates applied to three specified wires.
 
-       This class represents a quantum layer with a sequence of CX gates applied to three specified wires in the quantum device.
+    This class represents a quantum layer with a sequence of CX gates applied to three specified wires in the quantum device.
 
-       Args:
-           n_wires (int): Number of wires in the quantum device.
+    Args:
+        n_wires (int): Number of wires in the quantum device.
 
-       """
+    """
+
     def __init__(self, n_wires):
         super().__init__()
         self.n_wires = n_wires
@@ -562,14 +571,15 @@ class CXCXCXLayer(tq.QuantumModule):
 
 class SWAPSWAPLayer(tq.QuantumModule):
     """
-       Quantum layer with a sequence of SWAP gates applied to two specified pairs of wires.
+    Quantum layer with a sequence of SWAP gates applied to two specified pairs of wires.
 
-       This class represents a quantum layer with a sequence of SWAP gates applied to two specified pairs of wires in the quantum device.
+    This class represents a quantum layer with a sequence of SWAP gates applied to two specified pairs of wires in the quantum device.
 
-       Args:
-           n_wires (int): Number of wires in the quantum device.
+    Args:
+        n_wires (int): Number of wires in the quantum device.
 
-       """
+    """
+
     def __init__(self, n_wires):
         super().__init__()
         self.n_wires = n_wires
@@ -583,17 +593,18 @@ class SWAPSWAPLayer(tq.QuantumModule):
 
 class Op1QAllLayer(tq.QuantumModule):
     """
-        Quantum layer applying the same single-qubit operation to all wires.
+    Quantum layer applying the same single-qubit operation to all wires.
 
-        This class represents a quantum layer that applies the same single-qubit operation to all wires in the quantum device.
+    This class represents a quantum layer that applies the same single-qubit operation to all wires in the quantum device.
 
-        Args:
-            op (tq.Operator): Single-qubit operation to be applied.
-            n_wires (int): Number of wires in the quantum device.
-            has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
-            trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
+    Args:
+        op (tq.Operator): Single-qubit operation to be applied.
+        n_wires (int): Number of wires in the quantum device.
+        has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
+        trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
 
-        """
+    """
+
     def __init__(self, op, n_wires: int, has_params=False, trainable=False):
         super().__init__()
         self.n_wires = n_wires
@@ -610,21 +621,22 @@ class Op1QAllLayer(tq.QuantumModule):
 
 class Op2QAllLayer(tq.QuantumModule):
     """
-        Quantum layer applying the same two-qubit operation to all pairs of adjacent wires.
-        This class represents a quantum layer that applies the same two-qubit operation to all pairs of adjacent wires
-        in the quantum device. The pairs of wires can be determined in a circular or non-circular pattern based on the
-        specified jump.
+    Quantum layer applying the same two-qubit operation to all pairs of adjacent wires.
+    This class represents a quantum layer that applies the same two-qubit operation to all pairs of adjacent wires
+    in the quantum device. The pairs of wires can be determined in a circular or non-circular pattern based on the
+    specified jump.
 
-        Args:
-            op (tq.Operator): Two-qubit operation to be applied.
-            n_wires (int): Number of wires in the quantum device.
-            has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
-            trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
-            wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
-            jump (int, optional): Number of positions to jump between adjacent pairs of wires. Defaults to 1.
-            circular (bool, optional): Flag indicating if the pattern should be circular. Defaults to False.
+    Args:
+        op (tq.Operator): Two-qubit operation to be applied.
+        n_wires (int): Number of wires in the quantum device.
+        has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
+        trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
+        wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
+        jump (int, optional): Number of positions to jump between adjacent pairs of wires. Defaults to 1.
+        circular (bool, optional): Flag indicating if the pattern should be circular. Defaults to False.
 
     """
+
     """pattern:
     circular = False
     jump = 1: [0, 1], [1, 2], [2, 3], [3, 4], [4, 5]
@@ -679,20 +691,21 @@ class Op2QAllLayer(tq.QuantumModule):
 
 class Op2QFit32Layer(tq.QuantumModule):
     """
-        Quantum layer applying the same two-qubit operation to all pairs of adjacent wires, fitting to 32 operations.
+    Quantum layer applying the same two-qubit operation to all pairs of adjacent wires, fitting to 32 operations.
 
-        This class represents a quantum layer that applies the same two-qubit operation to all pairs of adjacent wires in the quantum device. The pairs of wires can be determined in a circular or non-circular pattern based on the specified jump. The layer is designed to fit to 32 operations by repeating the same operation pattern multiple times.
+    This class represents a quantum layer that applies the same two-qubit operation to all pairs of adjacent wires in the quantum device. The pairs of wires can be determined in a circular or non-circular pattern based on the specified jump. The layer is designed to fit to 32 operations by repeating the same operation pattern multiple times.
 
-        Args:
-            op (tq.Operator): Two-qubit operation to be applied.
-            n_wires (int): Number of wires in the quantum device.
-            has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
-            trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
-            wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
-            jump (int, optional): Number of positions to jump between adjacent pairs of wires. Defaults to 1.
-            circular (bool, optional): Flag indicating if the pattern should be circular. Defaults to False.
+    Args:
+        op (tq.Operator): Two-qubit operation to be applied.
+        n_wires (int): Number of wires in the quantum device.
+        has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
+        trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
+        wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
+        jump (int, optional): Number of positions to jump between adjacent pairs of wires. Defaults to 1.
+        circular (bool, optional): Flag indicating if the pattern should be circular. Defaults to False.
 
-        """
+    """
+
     def __init__(
         self,
         op,
@@ -732,18 +745,19 @@ class Op2QFit32Layer(tq.QuantumModule):
 
 class Op2QButterflyLayer(tq.QuantumModule):
     """
-        Quantum layer applying the same two-qubit operation in a butterfly pattern.
+    Quantum layer applying the same two-qubit operation in a butterfly pattern.
 
-        This class represents a quantum layer that applies the same two-qubit operation in a butterfly pattern. The butterfly pattern connects the first and last wire, the second and second-to-last wire, and so on, until the center wire(s) in the case of an odd number of wires.
+    This class represents a quantum layer that applies the same two-qubit operation in a butterfly pattern. The butterfly pattern connects the first and last wire, the second and second-to-last wire, and so on, until the center wire(s) in the case of an odd number of wires.
 
-        Args:
-            op (tq.Operator): Two-qubit operation to be applied.
-            n_wires (int): Number of wires in the quantum device.
-            has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
-            trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
-            wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
+    Args:
+        op (tq.Operator): Two-qubit operation to be applied.
+        n_wires (int): Number of wires in the quantum device.
+        has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
+        trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
+        wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
 
-        """
+    """
+
     """pattern: [0, 5], [1, 4], [2, 3]"""
 
     def __init__(
@@ -770,18 +784,19 @@ class Op2QButterflyLayer(tq.QuantumModule):
 
 class EntangleFull(tq.QuantumModule):
     """
-       Quantum layer applying the same two-qubit operation in a dense pattern.
+    Quantum layer applying the same two-qubit operation in a dense pattern.
 
-       This class represents a quantum layer that applies the same two-qubit operation in a dense pattern. The dense pattern connects every pair of wires, ensuring that each wire is connected to every other wire exactly once.
+    This class represents a quantum layer that applies the same two-qubit operation in a dense pattern. The dense pattern connects every pair of wires, ensuring that each wire is connected to every other wire exactly once.
 
-       Args:
-           op (tq.Operator): Two-qubit operation to be applied.
-           n_wires (int): Number of wires in the quantum device.
-           has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
-           trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
-           wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
+    Args:
+        op (tq.Operator): Two-qubit operation to be applied.
+        n_wires (int): Number of wires in the quantum device.
+        has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
+        trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
+        wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
 
-       """
+    """
+
     """pattern:
     [0, 1], [0, 2], [0, 3], [0, 4], [0, 5]
     [1, 2], [1, 3], [1, 4], [1, 5]
@@ -814,28 +829,31 @@ class EntangleFull(tq.QuantumModule):
                 self.ops_all[k](q_device, wires=wires)
                 k += 1
 
+
 # Adding an alias to the previous name
-Op2QDenseLayer = EntangleFull 
+Op2QDenseLayer = EntangleFull
+
 
 class LayerTemplate0(tq.QuantumModule):
     """
-       A template for a custom quantum layer.
+    A template for a custom quantum layer.
 
-       Args:
-           arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-       Attributes:
-           n_wires (int): The number of wires in the layer.
-           arch (dict): The architecture configuration for the layer.
-           n_blocks (int): The number of blocks in the layer. (Optional)
-           n_layers_per_block (int): The number of layers per block. (Optional)
-           layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer. (Optional)
+        n_layers_per_block (int): The number of layers per block. (Optional)
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-       Methods:
-           build_layers: Abstract method to build the layers of the template.
-           forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Abstract method to build the layers of the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-       """
+    """
+
     def __init__(self, arch: dict = None):
         super().__init__()
         self.n_wires = arch["n_wires"]
@@ -858,25 +876,24 @@ class LayerTemplate0(tq.QuantumModule):
 
 class U3CU3Layer0(LayerTemplate0):
     """
-        Layer template with U3 and CU3 blocks.
+    Layer template with U3 and CU3 blocks.
 
-        This layer template consists of U3 and CU3 blocks repeated for the specified number of blocks.
+    This layer template consists of U3 and CU3 blocks repeated for the specified number of blocks.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the U3 and CU3 layers for the template.
-            forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the U3 and CU3 layers for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-        """
-
+    """
 
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
@@ -901,25 +918,24 @@ class U3CU3Layer0(LayerTemplate0):
 
 class CU3Layer0(LayerTemplate0):
     """
-        Layer template with CU3 blocks.
+    Layer template with CU3 blocks.
 
-        This layer template consists of CU3 blocks repeated for the specified number of blocks.
+    This layer template consists of CU3 blocks repeated for the specified number of blocks.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the CU3 layers for the template.
-            forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the CU3 layers for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-        """
-
+    """
 
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
@@ -939,25 +955,24 @@ class CU3Layer0(LayerTemplate0):
 
 class CXRZSXLayer0(LayerTemplate0):
     """
-        Layer template with CXRZSX blocks.
+    Layer template with CXRZSX blocks.
 
-        This layer template consists of CXRZSX blocks, which include RZ, CNOT, and SX gates, repeated for the specified number of blocks.
+    This layer template consists of CXRZSX blocks, which include RZ, CNOT, and SX gates, repeated for the specified number of blocks.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the CXRZSX layers for the template.
-            forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the CXRZSX layers for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-        """
-
+    """
 
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
@@ -991,24 +1006,25 @@ class CXRZSXLayer0(LayerTemplate0):
 
 class SethLayer0(LayerTemplate0):
     """
-        Layer template with Seth blocks.
+    Layer template with Seth blocks.
 
-        This layer template consists of Seth blocks, which include RZZ and RY gates, repeated for the specified number of blocks.
+    This layer template consists of Seth blocks, which include RZZ and RY gates, repeated for the specified number of blocks.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the Seth layers for the template.
-            forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the Seth layers for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-        """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1032,24 +1048,25 @@ class SethLayer0(LayerTemplate0):
 
 class SethLayer1(LayerTemplate0):
     """
-       Layer template with extended Seth blocks.
+    Layer template with extended Seth blocks.
 
-       This layer template consists of extended Seth blocks, which include RZZ and RY gates repeated twice for each block.
+    This layer template consists of extended Seth blocks, which include RZZ and RY gates repeated twice for each block.
 
-       Args:
-           arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-       Attributes:
-           n_wires (int): The number of wires in the layer.
-           arch (dict): The architecture configuration for the layer.
-           n_blocks (int): The number of blocks in the layer.
-           layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-       Methods:
-           build_layers: Builds the extended Seth layers for the template.
-           forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the extended Seth layers for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-       """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1083,24 +1100,25 @@ class SethLayer1(LayerTemplate0):
 
 class SethLayer2(LayerTemplate0):
     """
-        Layer template with Seth blocks using Op2QFit32Layer.
+    Layer template with Seth blocks using Op2QFit32Layer.
 
-        This layer template consists of Seth blocks using the Op2QFit32Layer, which includes RZZ gates and supports 32 wires.
+    This layer template consists of Seth blocks using the Op2QFit32Layer, which includes RZZ gates and supports 32 wires.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the Seth layers with Op2QFit32Layer for the template.
-            forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the Seth layers with Op2QFit32Layer for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-        """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1119,24 +1137,25 @@ class SethLayer2(LayerTemplate0):
 
 class RZZLayer0(LayerTemplate0):
     """
-        Layer template with RZZ blocks.
+    Layer template with RZZ blocks.
 
-        This layer template consists of RZZ blocks using the Op2QAllLayer.
+    This layer template consists of RZZ blocks using the Op2QAllLayer.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the RZZ layers with Op2QAllLayer for the template.
-            forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the RZZ layers with Op2QAllLayer for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-        """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1155,24 +1174,25 @@ class RZZLayer0(LayerTemplate0):
 
 class BarrenLayer0(LayerTemplate0):
     """
-        Layer template with Barren blocks.
+    Layer template with Barren blocks.
 
-        This layer template consists of Barren blocks using the Op1QAllLayer and Op2QAllLayer.
+    This layer template consists of Barren blocks using the Op1QAllLayer and Op2QAllLayer.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the Barren layers with Op1QAllLayer and Op2QAllLayer for the template.
-            forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the Barren layers with Op1QAllLayer and Op2QAllLayer for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-        """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         layers_all.append(
@@ -1203,24 +1223,25 @@ class BarrenLayer0(LayerTemplate0):
 
 class FarhiLayer0(LayerTemplate0):
     """
-     Layer template with Farhi blocks.
+    Layer template with Farhi blocks.
 
-     This layer template consists of Farhi blocks using the Op2QAllLayer.
+    This layer template consists of Farhi blocks using the Op2QAllLayer.
 
-     Args:
-         arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-     Attributes:
-         n_wires (int): The number of wires in the layer.
-         arch (dict): The architecture configuration for the layer.
-         n_blocks (int): The number of blocks in the layer.
-         layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-     Methods:
-         build_layers: Builds the Farhi layers with Op2QAllLayer for the template.
-         forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the Farhi layers with Op2QAllLayer for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-     """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1249,24 +1270,25 @@ class FarhiLayer0(LayerTemplate0):
 
 class MaxwellLayer0(LayerTemplate0):
     """
-       Layer template with Maxwell blocks.
+    Layer template with Maxwell blocks.
 
-       This layer template consists of Maxwell blocks using the Op1QAllLayer and Op2QAllLayer modules.
+    This layer template consists of Maxwell blocks using the Op1QAllLayer and Op2QAllLayer modules.
 
-       Args:
-           arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-       Attributes:
-           n_wires (int): The number of wires in the layer.
-           arch (dict): The architecture configuration for the layer.
-           n_blocks (int): The number of blocks in the layer.
-           layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-       Methods:
-           build_layers: Builds the Maxwell layers with Op1QAllLayer and Op2QAllLayer for the template.
-           forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the Maxwell layers with Op1QAllLayer and Op2QAllLayer for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-       """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1321,24 +1343,25 @@ class MaxwellLayer0(LayerTemplate0):
 
 class RYRYCXLayer0(LayerTemplate0):
     """
-       Layer template with RYRYCX blocks.
+    Layer template with RYRYCX blocks.
 
-       This layer template consists of RYRYCX blocks using the Op1QAllLayer and CXLayer modules.
+    This layer template consists of RYRYCX blocks using the Op1QAllLayer and CXLayer modules.
 
-       Args:
-           arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-       Attributes:
-           n_wires (int): The number of wires in the layer.
-           arch (dict): The architecture configuration for the layer.
-           n_blocks (int): The number of blocks in the layer.
-           layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-       Methods:
-           build_layers: Builds the RYRYCX layers with Op1QAllLayer and CXLayer for the template.
-           forward: Applies the quantum layer to the given quantum device.
+    Methods:
+        build_layers: Builds the RYRYCX layers with Op1QAllLayer and CXLayer for the template.
+        forward: Applies the quantum layer to the given quantum device.
 
-       """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1353,23 +1376,23 @@ class RYRYCXLayer0(LayerTemplate0):
 
 class RYRYRYCXCXCXLayer0(LayerTemplate0):
     """
-       Layer template with RYRYRYCXCXCX blocks.
+    Layer template with RYRYRYCXCXCX blocks.
 
-       This layer template consists of RYRYRYCXCXCX blocks using the RYRYCXCXLayer module.
+    This layer template consists of RYRYRYCXCXCX blocks using the RYRYCXCXLayer module.
 
-       Args:
-           arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-       Attributes:
-           n_wires (int): The number of wires in the layer.
-           arch (dict): The architecture configuration for the layer.
-           n_blocks (int): The number of blocks in the layer.
-           layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-       Methods:
-           build_layers: Builds the RYRYRYCXCXCX layers with RYRYCXCXLayer for the template.
+    Methods:
+        build_layers: Builds the RYRYRYCXCXCX layers with RYRYCXCXLayer for the template.
 
-       """
+    """
 
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
@@ -1385,24 +1408,25 @@ class RYRYRYCXCXCXLayer0(LayerTemplate0):
 
 class RYRYRYLayer0(LayerTemplate0):
     """
-        Layer template with RYRYRYCXCXCX blocks.
+    Layer template with RYRYRYCXCXCX blocks.
 
-        This layer template consists of RYRYRYCXCXCX blocks using the Op1QAllLayer and CXCXCXLayer modules.
+    This layer template consists of RYRYRYCXCXCX blocks using the Op1QAllLayer and CXCXCXLayer modules.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the RYRYRYCXCXCX layers with Op1QAllLayer and CXCXCXLayer for the template.
+    Methods:
+        build_layers: Builds the RYRYRYCXCXCX layers with Op1QAllLayer and CXCXCXLayer for the template.
 
 
-        """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1416,24 +1440,25 @@ class RYRYRYLayer0(LayerTemplate0):
 
 class RYRYRYSWAPSWAPLayer0(LayerTemplate0):
     """
-        Layer template with RYRYRYSWAPSWAP blocks.
+    Layer template with RYRYRYSWAPSWAP blocks.
 
-        This layer template consists of RYRYRYSWAPSWAP blocks using the Op1QAllLayer and SWAPSWAPLayer modules.
+    This layer template consists of RYRYRYSWAPSWAP blocks using the Op1QAllLayer and SWAPSWAPLayer modules.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the RYRYRYSWAPSWAP layers with Op1QAllLayer and SWAPSWAPLayer for the template.
+    Methods:
+        build_layers: Builds the RYRYRYSWAPSWAP layers with Op1QAllLayer and SWAPSWAPLayer for the template.
 
 
-        """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1448,23 +1473,23 @@ class RYRYRYSWAPSWAPLayer0(LayerTemplate0):
 
 class SWAPSWAPLayer0(LayerTemplate0):
     """
-        Layer template with SWAPSWAP blocks.
+    Layer template with SWAPSWAP blocks.
 
-        This layer template consists of SWAPSWAP blocks using the SWAPSWAPLayer module.
+    This layer template consists of SWAPSWAP blocks using the SWAPSWAPLayer module.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the SWAPSWAP layers with SWAPSWAPLayer for the template.
+    Methods:
+        build_layers: Builds the SWAPSWAP layers with SWAPSWAPLayer for the template.
 
-        """
+    """
 
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
@@ -1475,23 +1500,24 @@ class SWAPSWAPLayer0(LayerTemplate0):
 
 class RXYZCXLayer0(LayerTemplate0):
     """
-        Layer template with RXYZCX blocks.
+    Layer template with RXYZCX blocks.
 
-        This layer template consists of RXYZCX blocks using the RXYZCXLayer module.
+    This layer template consists of RXYZCX blocks using the RXYZCXLayer module.
 
-        Args:
-            arch (dict, optional): The architecture configuration for the layer. Defaults to None.
+    Args:
+        arch (dict, optional): The architecture configuration for the layer. Defaults to None.
 
-        Attributes:
-            n_wires (int): The number of wires in the layer.
-            arch (dict): The architecture configuration for the layer.
-            n_blocks (int): The number of blocks in the layer.
-            layers_all (tq.QuantumModuleList): The list of layers in the template.
+    Attributes:
+        n_wires (int): The number of wires in the layer.
+        arch (dict): The architecture configuration for the layer.
+        n_blocks (int): The number of blocks in the layer.
+        layers_all (tq.QuantumModuleList): The list of layers in the template.
 
-        Methods:
-            build_layers: Builds the RXYZCX layers with RXYZCXLayer for the template.
+    Methods:
+        build_layers: Builds the RXYZCX layers with RXYZCXLayer for the template.
 
-        """
+    """
+
     def build_layers(self):
         layers_all = tq.QuantumModuleList()
         for k in range(self.arch["n_blocks"]):
@@ -1622,11 +1648,12 @@ class QFTLayer(tq.QuantumModule):
     def forward(self, q_device: tq.QuantumDevice):
         self.gates_all(q_device)
 
+
 class EntangleLinear(Op2QAllLayer):
     """
     Quantum layer applying the same two-qubit operation to all pairs of adjacent wires.
     This class represents a quantum layer that applies the same two-qubit operation to all pairs of adjacent wires
-    in the quantum device. 
+    in the quantum device.
 
     Args:
         op (tq.Operator): Two-qubit operation to be applied.
@@ -1635,6 +1662,7 @@ class EntangleLinear(Op2QAllLayer):
         trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
         wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
     """
+
     """pattern: [0, 1], [1, 2], [2, 3], [3, 4], [4, 5]
     """
 
@@ -1646,14 +1674,22 @@ class EntangleLinear(Op2QAllLayer):
         trainable=False,
         wire_reverse=False,
     ):
-        super().__init__(op=op, n_wires=n_wires, has_params=has_params, trainable=trainable, wire_reverse=wire_reverse, jump=1, circular=False)
+        super().__init__(
+            op=op,
+            n_wires=n_wires,
+            has_params=has_params,
+            trainable=trainable,
+            wire_reverse=wire_reverse,
+            jump=1,
+            circular=False,
+        )
 
 
 class EntangleCircular(Op2QAllLayer):
     """
     Quantum layer applying the same two-qubit operation to all pairs of adjacent wires in a circular manner.
     This class represents a quantum layer that applies the same two-qubit operation to all pairs of adjacent wires
-    in the quantum device with a wrap-around 
+    in the quantum device with a wrap-around
 
     Args:
         op (tq.Operator): Two-qubit operation to be applied.
@@ -1665,6 +1701,7 @@ class EntangleCircular(Op2QAllLayer):
         circular (bool, optional): Flag indicating if the pattern should be circular. Defaults to False.
 
     """
+
     """pattern: [0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 0]
     """
 
@@ -1676,13 +1713,20 @@ class EntangleCircular(Op2QAllLayer):
         trainable=False,
         wire_reverse=False,
     ):
-        super().__init__(op=op, n_wires=n_wires, has_params=has_params, trainable=trainable, wire_reverse=wire_reverse, jump=1, circular=True)
-
+        super().__init__(
+            op=op,
+            n_wires=n_wires,
+            has_params=has_params,
+            trainable=trainable,
+            wire_reverse=wire_reverse,
+            jump=1,
+            circular=True,
+        )
 
 
 class EntanglePairwise(tq.QuantumModule):
     """
-    Quantum layer applying the same two-qubit operation in a pair-wise pattern 
+    Quantum layer applying the same two-qubit operation in a pair-wise pattern
 
     This class represents a quantum layer that applies the same two-qubit operation in a pairwise pattern. The pairwise pattern first entangles all qubits i with i+1 for even i then all qubits i with i+1 for odd i.
 
@@ -1694,6 +1738,7 @@ class EntanglePairwise(tq.QuantumModule):
        wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
 
     """
+
     """pattern:
     [0, 1], [2, 3], [4, 5]
     [1, 2], [3, 4] 
@@ -1710,7 +1755,7 @@ class EntanglePairwise(tq.QuantumModule):
         # reverse the wires, for example from [1, 2] to [2, 1]
         self.wire_reverse = wire_reverse
 
-        for k in range(self.n_wires-1): 
+        for k in range(self.n_wires - 1):
             self.ops_all.append(op(has_params=has_params, trainable=trainable))
 
     def forward(self, q_device):
@@ -1719,7 +1764,7 @@ class EntanglePairwise(tq.QuantumModule):
         # entangle qubit i with i+1 for all even values of i
         for i in range(self.n_wires - 1):
             if i % 2 == 0:
-                wires = [i, i+1]
+                wires = [i, i + 1]
                 if self.wire_reverse:
                     wires.reverse()
                 self.ops_all[k](q_device, wires=wires)
@@ -1728,12 +1773,11 @@ class EntanglePairwise(tq.QuantumModule):
         # entangle qubit i with i+1 for all odd values of i
         for i in range(1, self.n_wires - 1):
             if i % 2 == 1:
-                wires = [i, i+1]
+                wires = [i, i + 1]
                 if self.wire_reverse:
                     wires.reverse()
                 self.ops_all[k](q_device, wires=wires)
                 k += 1
-
 
 
 layer_name_dict = {

--- a/torchquantum/layer/layers.py
+++ b/torchquantum/layer/layers.py
@@ -1788,7 +1788,7 @@ class EntanglementLayer(tq.QuantumModule):
     Args:
         op (tq.Operator): Two-qubit operation to be applied.
         n_wires (int): Number of wires in the quantum device.
-        entanglement_type (str): Type of entanglement from ["full", "linear", "pairwise", "circular"]
+        entanglement (str): Type of entanglement from ["full", "linear", "pairwise", "circular"]
         has_params (bool, optional): Flag indicating if the operation has parameters. Defaults to False.
         trainable (bool, optional): Flag indicating if the operation is trainable. Defaults to False.
         wire_reverse (bool, optional): Flag indicating if the order of wires in each pair should be reversed. Defaults to False.
@@ -1801,7 +1801,7 @@ class EntanglementLayer(tq.QuantumModule):
         self,
         op,
         n_wires: int,
-        entanglement_type: str,
+        entanglement: str,
         has_params=False,
         trainable=False,
         wire_reverse=False,
@@ -1815,11 +1815,11 @@ class EntanglementLayer(tq.QuantumModule):
             "circular": EntangleCircular,
         }
 
-        self.entanglement_class = entanglement_to_class.get(entanglement_type, None)
+        self.entanglement_class = entanglement_to_class.get(entanglement, None)
 
         assert (
             self.entanglement_class is not None
-        ), f"invalid entanglement type {entanglement_type}"
+        ), f"invalid entanglement type {entanglement}"
 
         self.entanglement_class.__init__(
             op=op,

--- a/torchquantum/plugin/qiskit/qiskit_unitary_gate.py
+++ b/torchquantum/plugin/qiskit/qiskit_unitary_gate.py
@@ -23,7 +23,6 @@ from qiskit.circuit import QuantumRegister, Qubit
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit._utils import _compute_control_matrix
 from qiskit.circuit.library.standard_gates import U3Gate
-from qiskit.extensions.quantum_initializer import isometry
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 from qiskit.quantum_info.synthesis.one_qubit_decompose import OneQubitEulerDecomposer
@@ -117,7 +116,7 @@ class UnitaryGate(Gate):
         else:
             q = QuantumRegister(self.num_qubits, "q")
             qc = QuantumCircuit(q, name=self.name)
-            qc.append(isometry.Isometry(self.to_matrix(), 0, 0), qargs=q[:])
+            qc.append(qiskit.circuit.library.Isometry(self.to_matrix(), 0, 0), qargs=q[:])
             self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -139,7 +138,7 @@ class UnitaryGate(Gate):
         cmat = _compute_control_matrix(
             self.to_matrix(), num_ctrl_qubits, ctrl_state=None
         )
-        iso = isometry.Isometry(cmat, 0, 0)
+        iso = qiskit.circuit.library.Isometry(cmat, 0, 0)
         cunitary = ControlledGate(
             "c-unitary",
             num_qubits=self.num_qubits + num_ctrl_qubits,


### PR DESCRIPTION
As discussed, added support for four entanglement types: EntangleFull, EntangleLinear, EntangleCircular, and EntanglePairwise. This is broken into two commits: the first adds the updates changes (would recommend focusing review there) and the second fixes the style of the layers.py file. 