### PR TITLE
Bugfix: Add qiskit runtime dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pylatexenc>=2.10
 pyscf>=2.0.1
 qiskit>=0.39.0,<1.0.0
 recommonmark
+qiskit_ibm_runtime==0.20.0
 
 scipy>=1.5.2
 setuptools>=52.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pyscf>=2.0.1
 qiskit>=0.39.0,<1.0.0
 recommonmark
 qiskit_ibm_runtime==0.20.0
+qiskit-aer==0.13.3
 
 scipy>=1.5.2
 setuptools>=52.0.0


### PR DESCRIPTION
Updated the qiskit runtime to be compatible with our stack (namely, qiskit<1.0.0).