### PR TITLE
Allow fixed parameters in GeneralEncoder

### DIFF
--- a/test/encoding/test_encodings.py
+++ b/test/encoding/test_encodings.py
@@ -1,0 +1,81 @@
+"""
+MIT License
+
+Copyright (c) 2020-present TorchQuantum Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# test the controlled unitary function
+
+
+import torchquantum as tq
+import torch
+from test.utils import check_all_close
+
+
+def test_GeneralEncoder():
+
+    parameterised_funclist = [
+        {"input_idx": [0], "func": "crx", "wires": [1, 0]},
+        {"input_idx": [1, 2, 3], "func": "u3", "wires": [1]},
+        {"input_idx": [4], "func": "ry", "wires": [0]},
+        {"input_idx": [5], "func": "ry", "wires": [1]},
+    ]
+
+    semiparam_funclist = [
+        {"params": [0.2], "func": "crx", "wires": [1, 0]},
+        {"params": [0.3, 0.4, 0.5], "func": "u3", "wires": [1]},
+        {"input_idx": [0], "func": "ry", "wires": [0]},
+        {"input_idx": [1], "func": "ry", "wires": [1]},
+    ]
+
+    expected_states = torch.complex(
+        torch.Tensor(
+            [[0.8423, 0.4474, 0.2605, 0.1384], [0.7649, 0.5103, 0.3234, 0.2157]]
+        ),
+        torch.Tensor(
+            [[-0.0191, 0.0522, -0.0059, 0.0162], [-0.0233, 0.0483, -0.0099, 0.0204]]
+        ),
+    )
+
+    parameterised_enc = tq.GeneralEncoder(parameterised_funclist)
+    semiparam_enc = tq.GeneralEncoder(semiparam_funclist)
+
+    param_vec = torch.Tensor(
+        [[0.2, 0.3, 0.4, 0.5, 0.6, 0.7], [0.2, 0.3, 0.4, 0.5, 0.8, 0.9]]
+    )
+    semiparam_vec = torch.Tensor([[0.6, 0.7], [0.8, 0.9]])
+
+    qd = tq.QuantumDevice(n_wires=2)
+
+    qd.reset_states(bsz=2)
+    parameterised_enc(qd, param_vec)
+    state1 = qd.get_states_1d()
+
+    qd.reset_states(bsz=2)
+    semiparam_enc(qd, semiparam_vec)
+    state2 = qd.get_states_1d()
+
+    check_all_close(state1, state2)
+    check_all_close(state1, expected_states)
+
+
+if __name__ == "__main__":
+    test_GeneralEncoder()

--- a/torchquantum/encoding/encodings.py
+++ b/torchquantum/encoding/encodings.py
@@ -90,7 +90,11 @@ class GeneralEncoder(Encoder, metaclass=ABCMeta):
     def forward(self, qdev: tq.QuantumDevice, x):
         for info in self.func_list:
             if tq.op_name_dict[info["func"]].num_params > 0:
-                params = x[:, info["input_idx"]]
+                # If params are provided in encoder, use those,
+                #  else use params from x
+                params = (torch.Tensor(info["params"]).repeat(x.shape[0], 1)
+                          if info.get("params")
+                          else x[:, info["input_idx"]])
             else:
                 params = None
             func_name_dict[info["func"]](

--- a/torchquantum/encoding/encodings.py
+++ b/torchquantum/encoding/encodings.py
@@ -80,6 +80,18 @@ class GeneralEncoder(Encoder, metaclass=ABCMeta):
     {'input_idx': [12, 13, 14], 'func': 'u3', 'wires': [3]},
     {'input_idx': [15], 'func': 'u1', 'wires': [3]},
     ]
+
+    Example 3:
+    [
+    {'params': [0.25], 'func': 'rx', 'wires': [0]},
+    {'params': [0.25], 'func': 'rx', 'wires': [1]},
+    {'params': [0.25], 'func': 'rx', 'wires': [2]},
+    {'params': [0.25], 'func': 'rx', 'wires': [3]},
+    {'input_idx': [0], 'func': 'ry', 'wires': [0]},
+    {'input_idx': [1], 'func': 'ry', 'wires': [1]},
+    {'input_idx': [2], 'func': 'ry', 'wires': [2]},
+    {'input_idx': [3], 'func': 'ry', 'wires': [3]}
+    ]
     """
 
     def __init__(self, func_list):


### PR DESCRIPTION
This PR adds the ability to fix parameters of some parameterised gates in a `GeneralEncoder`.

This allows, for example, a single parameterised gate to have a fixed parameter, shared across all items in the batch, while all other parameters can be dynamically provided. The change is fully backwards compatible, and no changes need to be made to existing encoder definitions.

This supports ansatze which have some fixed gates which aren't Paulis or other named operators.
I expect this could already be achieved by subclassing existing operators, but I think this imposes less effort on the user.

Opening this to gauge interest. Shall update documentation and tests pending feedback.

```
>>> import torchquantum as tq
>>> import torch
>>> 
>>> 
>>> enc1 = [{'input_idx': [0], 'func': 'rx', 'wires': [0]},
...        {'input_idx': [1], 'func': 'rx', 'wires': [1]},
...        {'input_idx': [2], 'func': 'rx', 'wires': [2]},
...        {'input_idx': [3], 'func': 'rx', 'wires': [3]}]
>>> 
>>> # Same as above, but now with 0.3 provided to the first RX gate always
>>> enc2 = [{'params': [0.3], 'func': 'rx', 'wires': [0]},
...        {'input_idx': [0], 'func': 'rx', 'wires': [1]},
...        {'input_idx': [1], 'func': 'rx', 'wires': [2]},
...        {'input_idx': [2], 'func': 'rx', 'wires': [3]}]
>>> 
>>> 
>>> e1 = tq.GeneralEncoder(enc1)
>>> e2 = tq.GeneralEncoder(enc2)
>>> 
>>> qdev = tq.QuantumDevice(4)
>>> 
>>> 
>>> params1 = torch.tensor([[0.3, 0.4, 0.5, 0.6], [0.3, 0, 0, 0]])
>>> params2 = torch.tensor([[0.4, 0.5, 0.6], [0, 0, 0]])
>>> 
>>> qdev.reset_states(2)
>>> e1(qdev, params1)
>>> print(qdev.get_states_1d())
tensor([[ 0.8970+0.0000j,  0.0000-0.2775j,  0.0000-0.2290j, -0.0709+0.0000j,
          0.0000-0.1818j, -0.0562+0.0000j, -0.0464+0.0000j,  0.0000+0.0144j,
          0.0000-0.1356j, -0.0419+0.0000j, -0.0346+0.0000j,  0.0000+0.0107j,
         -0.0275+0.0000j,  0.0000+0.0085j,  0.0000+0.0070j,  0.0022+0.0000j],
        [ 0.9888+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,
          0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,
          0.0000-0.1494j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,
          0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j]])
>>> 
>>> qdev.reset_states(2)
>>> e2(qdev, params2)
>>> print(qdev.get_states_1d())
tensor([[ 0.8970+0.0000j,  0.0000-0.2775j,  0.0000-0.2290j, -0.0709+0.0000j,
          0.0000-0.1818j, -0.0562+0.0000j, -0.0464+0.0000j,  0.0000+0.0144j,
          0.0000-0.1356j, -0.0419+0.0000j, -0.0346+0.0000j,  0.0000+0.0107j,
         -0.0275+0.0000j,  0.0000+0.0085j,  0.0000+0.0070j,  0.0022+0.0000j],
        [ 0.9888+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,
          0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,
          0.0000-0.1494j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,
          0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j,  0.0000+0.0000j]])
```