### PR TITLE
Support `qiskit2tq` to parse Qiskit’s `ParameterExpression`

### DIFF
--- a/torchquantum/layer/layers/module_from_ops.py
+++ b/torchquantum/layer/layers/module_from_ops.py
@@ -22,16 +22,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from typing import Iterable
+
+import numpy as np
 import torch
 import torch.nn as nn
+from torchpack.utils.logging import logger
+
 import torchquantum as tq
 import torchquantum.functional as tqf
-import numpy as np
-
-
-from typing import Iterable
 from torchquantum.plugin.qiskit import QISKIT_INCOMPATIBLE_FUNC_NAMES
-from torchpack.utils.logging import logger
 
 __all__ = [
     "QuantumModuleFromOps",
@@ -61,6 +61,6 @@ class QuantumModuleFromOps(tq.QuantumModule):
             None
 
         """
-        self.q_device = q_device
+        q_device.reset_states(1)
         for op in self.ops:
-            op(q_device)
+            op(q_device, wires=op.wires)


### PR DESCRIPTION
Resolve #263

Example (based on train_state_prep)

```python
import torch
import torch.optim as optim

import torchquantum as tq
from torch.optim.lr_scheduler import CosineAnnealingLR

import random
import numpy as np
from qiskit import QuantumCircuit
from qiskit.circuit import ParameterVector, Parameter
from torchquantum.plugin import qiskit2tq

ansatz = QuantumCircuit(2)
ansatz_param = Parameter("Θ") # parameter
ansatz.rx(ansatz_param, 0)
ansatz_param_vector = ParameterVector("φ", 9) # parameter vector
ansatz.u(ansatz_param_vector[0], ansatz_param_vector[1], ansatz_param_vector[2], 0)
ansatz.u(
    ansatz_param_vector[3] + ansatz_param_vector[1], # parameter expression
    ansatz_param_vector[4] * ansatz_param_vector[2],
    ansatz_param_vector[5] / ansatz_param_vector[0],
    1,
)
ansatz.cu(
    np.sin(ansatz_param_vector[6]), # numpy functions
    np.abs(np.sin(ansatz_param_vector[7])), # nested numpy functions
    # complex expression
    np.abs(np.sin(ansatz_param_vector[8])) * np.exp(ansatz_param_vector[1] + ansatz_param_vector[2]),
    0.0,
    0,
    1,
)

# partially assigning the parameters
ansatz.assign_parameters({ansatz_param_vector[1]: 0.1})


def train(target_state, device, model, optimizer):
    model(device)
    result_state = device.get_states_1d()[0]

    # compute the state infidelity
    loss = 1 - torch.dot(result_state, target_state).abs() ** 2

    optimizer.zero_grad()
    loss.backward()
    optimizer.step()
    print(
        f"infidelity (loss): {loss.item()}, \n target state : "
        f"{target_state.detach().cpu().numpy()}, \n "
        f"result state : {result_state.detach().cpu().numpy()}\n"
    )


seed = 42
random.seed(seed)
np.random.seed(seed)
torch.manual_seed(seed)

device = torch.device("cpu")
model = qiskit2tq(ansatz).to(device)
print(model)

n_epochs = 10
optimizer = optim.Adam(model.parameters(), lr=1e-2, weight_decay=0)
scheduler = CosineAnnealingLR(optimizer, T_max=n_epochs)

q_device = tq.QuantumDevice(n_wires=2)
target_state = torch.tensor([0, 1, 0, 0], dtype=torch.complex64)

for epoch in range(1, n_epochs + 1):
    print(f"Epoch {epoch}, LR: {optimizer.param_groups[0]['lr']}")
    train(target_state, q_device, model, optimizer)
    scheduler.step()
```