### PR TITLE
Fix MeasureMulti*PauliSum

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Researchers on quantum algorithm design, parameterized quantum circuit training,
 Dynamic computation graph, automatic gradient computation, fast GPU support, batch model tersorized processing.
 
 ## News
+- Torchquantum is used in the winning team for ACM Quantum Computing for Drug Discovery Challenge.
+- Torchquantum is highlighted in [UnitaryHack](https://unitaryhack.dev/projects/torchquantum/).
+- TorchQuantum received [UnitaryFund](https://unitary.fund/).
+- TorchQuantum is integrated to [IBM Qiskit Ecosystem](https://qiskit.github.io/ecosystem/).
+- TorchQuantum is integrated to [PyTorch Ecosystem](https://pytorch.org/ecosystem/).
 - v0.1.8 Available!
 - Check the [dev branch](https://github.com/mit-han-lab/torchquantum/tree/dev) for new latest features on quantum layers and quantum algorithms.
 - Join our [Slack](https://join.slack.com/t/torchquantum/shared_invite/zt-1ghuf283a-OtP4mCPJREd~367VX~TaQQ) for real time support!

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 dill==0.3.4
 matplotlib>=3.3.2
 nbsphinx
-numpy>=1.19.2
+numpy>=1.19.2,<2
 
 opt_einsum
 pathos>=0.2.7

--- a/torchquantum/measurement/measurements.py
+++ b/torchquantum/measurement/measurements.py
@@ -424,7 +424,7 @@ class MeasureMultiPauliSum(tq.QuantumModule):
         )
 
     def forward(self, qdev: tq.QuantumDevice):
-        res_all = self.measure_multiple_times(qdev)
+        res_all = self.measure_multiple_times(qdev).prod(-1)
 
         return res_all.sum(-1)
 
@@ -452,8 +452,9 @@ class MeasureMultiQubitPauliSum(tq.QuantumModule):
         )
 
     def forward(self, qdev: tq.QuantumDevice):
-        res_all = self.measure_multiple_times(qdev)
-        return (res_all * self.obs_list[0]["coefficient"]).sum(-1)
+        res_all = self.measure_multiple_times(qdev).prod(-1)
+        
+        return (res_all * torch.tensor(self.obs_list[0]["coefficient"])).sum(-1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Not sure whether I am misunderstanding the function.

self.measure_multiple_times returns a [len(obs_list), num_wires] tensor, you have to take the product over the wires first to get the measurement of the Pauli string and then sum over the obs_list (multiplied by coefficients in the case of MeasureMultiQubitPaulisum.