### PR TITLE
Fix for issue #213

### DIFF
--- a/examples/clifford_qnn/mnist_clifford_qnn.py
+++ b/examples/clifford_qnn/mnist_clifford_qnn.py
@@ -60,6 +60,7 @@ class QFCModel(tq.QuantumModule):
                 self.q_device, self.encoder, self.q_layer, self.measure, x
             )
         else:
+            self.q_device = tq.QuantumDevice(n_wires=self.n_wires, bsz=bsz)
             self.encoder(self.q_device, x)
             self.q_layer(self.q_device)
             x = self.measure(self.q_device)

--- a/torchquantum/operator/op_types.py
+++ b/torchquantum/operator/op_types.py
@@ -7,6 +7,7 @@ from abc import ABCMeta
 from ..macro import C_DTYPE, F_DTYPE
 from typing import Iterable, Union, List
 from enum import IntEnum
+from torchquantum.util.quantization.clifford_quantization import CliffordQuantizer
 
 __all__ = [
     "Operator",

--- a/torchquantum/operator/op_types.py
+++ b/torchquantum/operator/op_types.py
@@ -7,7 +7,6 @@ from abc import ABCMeta
 from ..macro import C_DTYPE, F_DTYPE
 from typing import Iterable, Union, List
 from enum import IntEnum
-from torchquantum.util.quantization.clifford_quantization import CliffordQuantizer
 
 __all__ = [
     "Operator",
@@ -246,6 +245,7 @@ class Operator(tq.QuantumModule):
                 params = self.params
 
             if self.clifford_quantization:
+                from torchquantum.util.quantization.clifford_quantization import CliffordQuantizer
                 params = CliffordQuantizer.quantize_sse(params)
             if self.n_wires is None:
                 self.func(q_device, self.wires, params=params, inverse=self.inverse)


### PR DESCRIPTION
To fix issue mit-han-lab/torchquantum#213, it looks like the ```QuantumDevice``` needs to be initialized with the batch size (batch size is 1 by default which is why the size was [1, 2] instead of [256, 2]). 

After this change, there is a ```NameError``` for ```CliffordQuantizer```:
![image](https://github.com/user-attachments/assets/c79abc0e-3d3f-457c-bfd8-77d6c9ec306b)
which can be fixed by importing it in the ```torchquantum/operator/op_types.py``` file, which calls the ```CliffordQuantizer``` function.

After these changes, I believe ```examples/clifford_qnn/mnist_clifford_qnn.py``` can run out-of-the-box:
![clifford_success](https://github.com/user-attachments/assets/18255da5-d26c-40f0-a72a-c817b70ce261)
@Hanrui-Wang @01110011011101010110010001101111 