### PR TITLE
Fix measurement

### DIFF
--- a/test/measurement/test_measuremultipletimes.py
+++ b/test/measurement/test_measuremultipletimes.py
@@ -1,0 +1,57 @@
+import numpy as np
+import torchquantum as tq
+
+
+def test_non_trivial_pauli_expectation():
+    class TestCircuit(tq.QuantumModule):
+        def __init__(self):
+            super().__init__()
+
+            self.meas = tq.measurement.MeasureMultipleTimes([
+                {'wires': range(2), 'observables': 'xx'},
+                {'wires': range(2), 'observables': 'yy'},
+                {'wires': range(2), 'observables': 'zz'},
+            ])
+
+        def forward(self, qdev: tq.QuantumDevice):
+            """
+                Prepare and measure the expexctation value of the state
+                    exp(-i pi/8)/sqrt(2) * (cos pi/12,
+                                            -i sin pi/12,
+                                            -i sin pi/12 * exp(i pi/4),
+                                            -i sin pi/12 * exp(i pi/4))
+            """
+            # prepare bell state
+            tq.h(qdev, 0)
+            tq.cnot(qdev, [0, 1])
+
+            # add some phases
+            tq.rz(qdev, wires=0, params=np.pi / 4)
+            tq.rx(qdev, wires=1, params=np.pi / 6)
+            return self.meas(qdev)
+
+    test_circuit = TestCircuit()
+    qdev = tq.QuantumDevice(bsz=1, n_wires=2)  # Batch size 1 for testing
+
+    # Run the circuit
+    meas_results = test_circuit(qdev)[0]
+
+    # analytical results for XX, YY, ZZ expval respectively
+    expval_xx = np.cos(np.pi / 4)
+    expval_yy = -np.cos(np.pi / 4) * np.cos(np.pi / 6)
+    expval_zz = np.cos(np.pi / 6)
+
+    atol = 1e-6
+
+    assert np.isclose(meas_results[0].item(), expval_xx, atol=atol), \
+        f"Expected {expval_xx}, got {meas_results[0].item()}"
+    assert np.isclose(meas_results[1].item(), expval_yy, atol=atol), \
+        f"Expected {expval_yy}, got {meas_results[1].item()}"
+    assert np.isclose(meas_results[2].item(), expval_zz, atol=atol), \
+        f"Expected {expval_zz}, got {meas_results[2].item()}"
+
+    print("Test passed!")
+
+
+if __name__ == "__main__":
+    test_non_trivial_pauli_expectation()

--- a/torchquantum/measurement/measurements.py
+++ b/torchquantum/measurement/measurements.py
@@ -23,7 +23,6 @@ __all__ = [
     "expval",
     "MeasureAll",
     "MeasureMultipleTimes",
-    "MeasureMultiPauliSum",
     "MeasureMultiQubitPauliSum",
     "gen_bitstrings",
     "measure",
@@ -394,37 +393,6 @@ class MeasureMultipleTimes(tq.QuantumModule):
 
     def set_v_c_reg_mapping(self, mapping):
         self.v_c_reg_mapping = mapping
-
-
-class MeasureMultiPauliSum(tq.QuantumModule):
-    """
-    similar to qiskit.opflow PauliSumOp
-    obs list:
-    list of dict: example
-    [{'wires': [0, 2, 3, 1],
-    'observables': ['x', 'y', 'z', 'i'],
-    'coefficient': [1, 0.5, 0.4, 0.3]
-    },
-    {'wires': [0, 2, 3, 1],
-    'observables': ['x', 'y', 'z', 'i'],
-    'coefficient': [1, 0.5, 0.4, 0.3]
-    },
-    ]
-    """
-
-    def __init__(self, obs_list, v_c_reg_mapping=None):
-        super().__init__()
-        self.obs_list = obs_list
-        self.v_c_reg_mapping = v_c_reg_mapping
-        self.measure_multiple_times = MeasureMultipleTimes(
-            obs_list=obs_list, v_c_reg_mapping=v_c_reg_mapping
-        )
-
-    def forward(self, qdev: tq.QuantumDevice):
-        # returns batch x len(obs_list) object, return sum
-        res_all = self.measure_multiple_times(qdev)
-
-        return res_all.sum(-1)
 
 
 class MeasureMultiQubitPauliSum(tq.QuantumModule):


### PR DESCRIPTION
This is sort of a follow-up on #288, I misunderstood the functions, the fix there was wrong (as was the original function).

If I understand correctly, the example in the docstring

```
class MeasureMultipleTimes(tq.QuantumModule):
    """
    obs list:
    list of dict: example
    [{'wires': [0, 2, 3, 1], 'observables': ['x', 'y', 'z', 'i']
    },
    {'wires': [0, 2, 3, 1], 'observables': ['x', 'y', 'z', 'i']
    },
    ]
    """
```

means that we measure the expectation value of `X x Y x Z x I` tensor product and then of `X x Y x Z x I` (i.e. the same state).

We expect this to return `[batch_size, len(obs_list)]` and not `[batch_size, len(obs_list), num_wires]`, you cannot get anything separated by wires from here, the expectation value of the tensor product is just a real number, thus `expval_joint_analytical` is needed here. I have removed the prod from `MeasureMultiQubitPauliSum`.

In fact, I don't really see any use case for `expval` as implemented here. IMO it should be renamed to `expval_per_wire` and it should be made explicit that the observables are looped over and the i-th return value is the expectation value of the i-th observable w.r.t. to the i-th wire (with the rest traced out). What is the use case for this over just expval_joint_analytical?

Further, I have removed MeasureMultiPauliSum, it passes `obs_list` to `MeasureMultipleTimes` but `MeasureMultipleTimes` does not take into account the `coefficient` entry that is specified in `MeasureMultiPauliSum`. Thus, `MeasureMultiPauliSum` will not fail (since it is a correct dict with too many keys) but also not return the correct value. Since I have no interest in implementing this correctly, I would remove.