### PR TITLE
Pass device to Hamiltonian, pass to pauli_string_to_matrix

### DIFF
--- a/torchquantum/algorithm/hamiltonian.py
+++ b/torchquantum/algorithm/hamiltonian.py
@@ -28,7 +28,7 @@ import torchquantum as tq
 import torchquantum.functional as tqf
 import numpy as np
 
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, Union
 from torchquantum.util import pauli_string_to_matrix
 
 __all__ = ["Hamiltonian"]
@@ -96,6 +96,7 @@ class Hamiltonian(object):
                  coeffs: List[float],
                  paulis: List[str],
                  endianness: str = "big",
+                 device: Union[torch.device, str, None] = None
                  ) -> None:
         """Initialize the Hamiltonian.
         Args:
@@ -125,6 +126,8 @@ class Hamiltonian(object):
         self.coeffs = coeffs
         self.paulis = paulis
         self.endianness = endianness
+        self.dev = (torch.device(device) if isinstance(device, str)
+                    else device)
         if self.endianness == "little":
             self.paulis = [pauli[::-1] for pauli in self.paulis]
     
@@ -135,9 +138,11 @@ class Hamiltonian(object):
     
     def get_matrix(self) -> torch.Tensor:
         """Return the matrix of the Hamiltonian."""
-        matrix = self.coeffs[0] * pauli_string_to_matrix(self.paulis[0])
+        matrix = self.coeffs[0] * pauli_string_to_matrix(self.paulis[0],
+                                                         device=self.dev)
         for coeff, pauli in zip(self.coeffs[1:], self.paulis[1:]):
-            matrix += coeff * pauli_string_to_matrix(pauli)
+            matrix += coeff * pauli_string_to_matrix(pauli,
+                                                     device=self.dev)
 
         return matrix
     


### PR DESCRIPTION
`pauli_string_to_matrix` takes a device argument, which defaults to `torch.device('cpu')`:

https://github.com/mit-han-lab/torchquantum/blob/611cc2ac9d5d7490114ec4ca175c2b74e0951f38/torchquantum/util/utils.py#L990

When trying to use `Hamiltonian` on GPU this invariably leads to device errors, since the result from `pauli_string_to_matrix` will be on CPU, so it would be nice to be able to pass device to Hamiltonian, which passes it on to `pauli_string_to_matrix`. Setting the default to `None` ensures that not previous behaviour is changed.