### PR TITLE
Align python_requires, addition of requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------
+# Development Requirements for TorchQuantum
+# ---------------------------------------------------------------------------
+# This file lists dependencies needed for developing TorchQuantum,
+# including testing, linting, formatting, and building documentation.
+# Use 'pip install -r requirements-dev.txt' to install these.
+# ---------------------------------------------------------------------------
+
+# Include the core library requirements
+-r requirements.txt
+
+# === Code Style & Linting ===
+# Used via pre-commit hooks (as mentioned in README)
+pre-commit>=2.15.0   # Manages git hooks for checks
+black>=22.3.0        # Uncompromising Python code formatter
+# You might add other linters like flake8 or isort here if the project uses them
+
+# === Testing ===
+pytest>=6.0.0        # Standard testing framework for Python
+# Add other testing plugins if needed (e.g., pytest-cov for coverage)
+
+# === Documentation Building ===
+# Dependencies needed to build the documentation locally (from setup.py extras)
+Sphinx>=4.0.0        # Documentation generator tool
+nbsphinx             # Sphinx extension for rendering Jupyter Notebooks
+recommonmark         # Sphinx extension for Markdown support
+# Add any other specific themes or extensions used (e.g., sphinx_rtd_theme)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         license="MIT",
         install_requires=requirements,
         extras_require={"doc": ["nbsphinx", "recommonmark"]},
-        python_requires=">=3.5",
+        python_requires=">=3.7",# Align with README
         include_package_data=True,
         packages=find_packages(),
     )


### PR DESCRIPTION
Hi,
Based on my experience setting up the repo, I've made two small improvements:

1.  **Updated `python_requires` in `setup.py`:** Changed to `>=3.7` to better align with the README and common ecosystem versions.
2.  **Added `requirements-dev.txt`:** This separates development-only dependencies (like `pytest`, `black`, `pre-commit`, `Sphinx`) from the core ones in `requirements.txt`. It clarifies setup for contributors (e.g., via `pip install -r requirements-dev.txt`).

Hope this improves setup clarity and consistency! Amazing repo byt the way