### PR TITLE
fix(qiskit): Update AerSampler import to SamplerV2 for Qiskit compatibility

### DIFF
--- a/torchquantum/plugin/qiskit/qiskit_processor.py
+++ b/torchquantum/plugin/qiskit/qiskit_processor.py
@@ -35,8 +35,7 @@ from qiskit_aer.noise import NoiseModel
 # Removed: from .my_job_monitor import my_job_monitor as job_monitor
 # Removed: from qiskit.providers.ibmq import IBMQ
 from qiskit_ibm_runtime import QiskitRuntimeService # Changed provider to runtime
-# from qiskit_aer.primitives import SamplerV2 as AerSamplerV2 # Added
-from qiskit_aer.primitives import Sampler as AerSampler
+from qiskit_aer.primitives import SamplerV2 as AerSampler
 from qiskit_ibm_runtime import SamplerV2 as RuntimeSampler # Changed provider to runtime
 from qiskit.primitives.containers import PubResult # Added
 from qiskit.exceptions import QiskitError
@@ -225,7 +224,7 @@ class QiskitProcessor(object):
             backend_opts = {"noise_model": self.noise_model} if self.noise_model else {}
             # Initialize Sampler with options
             self.sampler = AerSampler(options={"backend_options": backend_opts}, seed=self.seed_simulator)
-            logger.info(f"Initialized AerSampler.{' With noise model.' if self.noise_model else ''}")
+            logger.info(f"Initialized AerSamplerV2.{' With noise model.' if self.noise_model else ''}")
 
     def set_layout(self, layout):
         self.initial_layout = layout


### PR DESCRIPTION
## Summary

Fixes #303

The `qiskit_aer.primitives.Sampler` class has been deprecated in newer Qiskit versions, and its constructor signature changed, causing the error:
```
Sampler.__init__() got an unexpected keyword argument 'options'
```

This PR updates the import to use `SamplerV2` as recommended by @zkysfls in issue #303.

## Changes

- Updated import from `from qiskit_aer.primitives import Sampler as AerSampler` to `from qiskit_aer.primitives import SamplerV2 as AerSampler`
- Updated logger message to reflect `AerSamplerV2`
- Removed commented-out duplicate import

## Why SamplerV2?

According to [Qiskit Aer documentation](https://qiskit.github.io/qiskit-aer/stubs/qiskit_aer.primitives.SamplerV2.html), `SamplerV2`:
- Supports the `options` parameter with `backend_options` (matching our existing code)
- Supports the `seed` parameter (matching our existing code)
- Is the recommended primitive for Qiskit Aer going forward

## Backward Compatibility

The existing code already uses the SamplerV2-compatible interface:
```python
self.sampler = AerSampler(options={"backend_options": backend_opts}, seed=self.seed_simulator)
```

By aliasing `SamplerV2` as `AerSampler`, no other code changes are required.

## Test plan

- [ ] Verify import works with latest qiskit-aer (0.17.x)
- [ ] Run basic quantum circuit simulation
- [ ] Test with noise model enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)