### PR TITLE
fix: Remove pyscf from dependencies

### DIFF
--- a/requirement_update.txt
+++ b/requirement_update.txt
@@ -7,7 +7,6 @@ numpy
 opt_einsum
 pathos
 pylatexenc
-pyscf
 qiskit
 recommonmark
 qiskit_ibm_runtime

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ numpy>=1.19.2
 opt_einsum
 pathos>=0.2.7
 pylatexenc>=2.10
-pyscf>=2.0.1
 qiskit==1.4.3
 recommonmark
 qiskit_ibm_runtime


### PR DESCRIPTION
## Summary

Fixes #286

This PR removes `pyscf` from the dependencies as it:
1. Is not used anywhere in the torchquantum codebase
2. Causes installation failures on Windows due to CMake/build issues

## Changes

- Removed `pyscf>=2.0.1` from `requirements.txt`
- Removed `pyscf` from `requirement_update.txt`

## Related Issues

- #266 - Also mentions pyscf installation issues
- #225 - Unable to install requirements (same root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)