### PR TITLE
fix: Correct conjugate transpose in apply_unitary_density_bmm

### DIFF
--- a/torchquantum/density/density_func.py
+++ b/torchquantum/density/density_func.py
@@ -205,9 +205,16 @@ def apply_unitary_density_bmm(density, mat, wires):
     new_density = new_density.view(original_shape).permute(permute_back)
     _matrix = torch.reshape(new_density[0], [2 ** n_qubit] * 2)
     """
-    Compute \rho U^\dagger 
+    Compute \rho U^\dagger
     """
-    matdag = torch.conj(mat)
+    # Fix for issue #254: Need conjugate transpose, not just conjugate
+    # U† = (U*)^T where U* is element-wise conjugate and ^T is transpose
+    if len(mat.shape) > 2:
+        # Batched matrices: swap last two dimensions
+        matdag = torch.conj(mat.permute(0, 2, 1))
+    else:
+        # Single matrix: transpose
+        matdag = torch.conj(mat.permute(1, 0))
     matdag = matdag.type(C_DTYPE).to(density.device)
 
     devices_dims_dag = [n_qubit + w + 1 for w in device_wires]

--- a/torchquantum/functional/gate_wrapper.py
+++ b/torchquantum/functional/gate_wrapper.py
@@ -296,9 +296,16 @@ def apply_unitary_density_bmm(density, mat, wires):
         new_density = mat.expand(expand_shape).bmm(permuted)
     new_density = new_density.view(original_shape).permute(permute_back)
     """
-    Compute \rho U^\dagger 
+    Compute \rho U^\dagger
     """
-    matdag = torch.conj(mat)
+    # Fix for issue #254: Need conjugate transpose, not just conjugate
+    # U† = (U*)^T where U* is element-wise conjugate and ^T is transpose
+    if len(mat.shape) > 2:
+        # Batched matrices: swap last two dimensions
+        matdag = torch.conj(mat.permute(0, 2, 1))
+    else:
+        # Single matrix: transpose
+        matdag = torch.conj(mat.permute(1, 0))
     matdag = matdag.type(C_DTYPE).to(density.device)
 
     devices_dims_dag = [n_qubit + w + 1 for w in device_wires]


### PR DESCRIPTION
## Summary

Fixes #254

This PR fixes a critical bug in the `apply_unitary_density_bmm` function where the density matrix evolution ρ → U ρ U† was computed incorrectly.

## The Bug

The code was computing only the conjugate of the matrix instead of the conjugate transpose (Hermitian adjoint):

```python
# Before (WRONG)
matdag = torch.conj(mat)  # Only conjugate, missing transpose

# After (CORRECT)
if len(mat.shape) > 2:
    matdag = torch.conj(mat.permute(0, 2, 1))  # Batched
else:
    matdag = torch.conj(mat.permute(1, 0))     # Single
```

For U† (Hermitian adjoint), we need both:
- Element-wise complex conjugation (U*)
- Matrix transposition (^T)

## Example

As reported in the issue, applying Y gate to |00⟩⟨00| was giving wrong results:
- **Expected**: diag(0, 1, 0, 0) 
- **Got**: Incorrect matrix

## Files Changed

- `torchquantum/functional/gate_wrapper.py` - line 301
- `torchquantum/density/density_func.py` - line 210

## Note

The einsum implementation (`apply_unitary_density_einsum`) was already correct. This fix aligns the bmm implementation with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)