### PR TITLE
Fix Hadamard gate docstrings and type hints

### DIFF
--- a/torchquantum/functional/hadamard.py
+++ b/torchquantum/functional/hadamard.py
@@ -34,7 +34,7 @@ _hadamard_mat_dict = {
 
 def hadamard(
     q_device: QuantumDevice,
-    wires: Union[List[int], int],
+    wires: int,
     params: torch.Tensor = None,
     n_wires: int = None,
     static: bool = False,
@@ -46,7 +46,7 @@ def hadamard(
 
     Args:
         q_device (tq.QuantumDevice): The QuantumDevice.
-        wires (Union[List[int], int]): Which qubit(s) to apply the gate.
+        wires (int): Which qubit to apply the gate.
         params (torch.Tensor, optional): Parameters (if any) of the gate.
             Default to None.
         n_wires (int, optional): Number of qubits the gate is applied to.
@@ -81,7 +81,7 @@ def hadamard(
 
 def shadamard(
     q_device,
-    wires,
+    wires: int,
     params=None,
     n_wires=None,
     static=False,
@@ -93,7 +93,7 @@ def shadamard(
 
     Args:
         q_device (tq.QuantumDevice): The QuantumDevice.
-        wires (Union[List[int], int]): Which qubit(s) to apply the gate.
+        wires (int): Which qubit to apply the gate.
         params (torch.Tensor, optional): Parameters (if any) of the gate.
             Default to None.
         n_wires (int, optional): Number of qubits the gate is applied to.
@@ -128,7 +128,7 @@ def shadamard(
 
 def chadamard(
     q_device,
-    wires,
+    wires: List[int],
     params=None,
     n_wires=None,
     static=False,
@@ -136,11 +136,11 @@ def chadamard(
     inverse=False,
     comp_method="bmm",
 ):
-    """Perform the chadamard gate.
+    """Perform the controlled hadamard gate.
 
     Args:
         q_device (tq.QuantumDevice): The QuantumDevice.
-        wires (Union[List[int], int]): Which qubit(s) to apply the gate.
+        wires (List[int]): Which qubits to apply the gate (control and target).
         params (torch.Tensor, optional): Parameters (if any) of the gate.
             Default to None.
         n_wires (int, optional): Number of qubits the gate is applied to.
@@ -160,7 +160,7 @@ def chadamard(
 
     name = "chadamard"
 
-    mat = mat_dict[name]
+    mat = _hadamard_mat_dict[name]
     gate_wrapper(
         name=name,
         mat=mat,


### PR DESCRIPTION
## Summary
- Fix `hadamard()` and `shadamard()` docstrings: Changed `wires` type from `Union[List[int], int]` to `int` since these are single-qubit gates (`num_wires = 1`)
- Fix `chadamard()` docstring: Clarified it's a controlled gate requiring a list of 2 qubits (control and target)
- Fix bug: `chadamard()` was referencing undefined `mat_dict` instead of `_hadamard_mat_dict`

## Test plan
- [x] Verify type hints match the `num_wires` attribute in class definitions
- [ ] Run existing tests to ensure no regressions

Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)