### PR TITLE
Fix apply_readout_error to use correct qubit mapping

### DIFF
--- a/torchquantum/noise_model/noise_models.py
+++ b/torchquantum/noise_model/noise_models.py
@@ -474,10 +474,10 @@ class NoiseModelTQ(object):
         return ops
 
     def apply_readout_error(self, x):
-        c2p_mapping = self.p_c_reg_mapping["c2p"]
+        c2v_mapping = self.v_c_reg_mapping["c2v"]
         measure_info = self.parsed_dict["measure"]
 
-        return apply_readout_error_func(x, c2p_mapping, measure_info)
+        return apply_readout_error_func(x, c2v_mapping, measure_info)
 
 
 class NoiseModelTQActivation(object):
@@ -713,10 +713,10 @@ class NoiseModelTQActivationReadout(NoiseModelTQActivation):
         self.parsed_dict = NoiseModelTQ.parse_noise_model_dict(self.noise_model_dict)
 
     def apply_readout_error(self, x):
-        c2p_mapping = self.p_c_reg_mapping["c2p"]
+        c2v_mapping = self.v_c_reg_mapping["c2v"]
         measure_info = self.parsed_dict["measure"]
 
-        return apply_readout_error_func(x, c2p_mapping, measure_info)
+        return apply_readout_error_func(x, c2v_mapping, measure_info)
 
 
 class NoiseModelTQPhaseReadout(NoiseModelTQPhase):
@@ -759,7 +759,7 @@ class NoiseModelTQPhaseReadout(NoiseModelTQPhase):
         self.parsed_dict = NoiseModelTQ.parse_noise_model_dict(self.noise_model_dict)
 
     def apply_readout_error(self, x):
-        c2p_mapping = self.p_c_reg_mapping["c2p"]
+        c2v_mapping = self.v_c_reg_mapping["c2v"]
         measure_info = self.parsed_dict["measure"]
 
-        return apply_readout_error_func(x, c2p_mapping, measure_info)
+        return apply_readout_error_func(x, c2v_mapping, measure_info)


### PR DESCRIPTION
## Summary
Changed `c2p_mapping` (classical to physical) to `c2v_mapping` (classical to virtual) in `apply_readout_error` methods across all NoiseModel classes.

This aligns the noise model's behavior with the measurement module which correctly uses `v_c_reg_mapping["c2v"]` for mapping classical measurement results to logical qubit indices.

## Changes
- `NoiseModelTQ.apply_readout_error()` (line 477)
- `NoiseModelTQPhase.apply_readout_error()` (line 716)
- `NoiseModelTQPhaseReadout.apply_readout_error()` (line 762)

## Test plan
- [ ] Test readout error application with transpiled circuits
- [ ] Verify measurement outcomes match expected noise characteristics

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)