### PR TITLE
Add warning for nn.ModuleList usage with quantum gates

### DIFF
--- a/torchquantum/module/modules.py
+++ b/torchquantum/module/modules.py
@@ -24,6 +24,7 @@ SOFTWARE.
 
 import torch.nn as nn
 import torchquantum as tq
+import warnings
 
 from abc import ABCMeta
 from typing import Iterable
@@ -256,6 +257,15 @@ class QuantumModule(nn.Module):
                 # be the same as the parent graph because ModuleList and
                 # ModuleDict do not call the forward function
                 module.graph = self.graph
+                # Warn if using nn.ModuleList instead of tq.QuantumModuleList
+                if not isinstance(module, (tq.QuantumModuleList, tq.QuantumModuleDict)):
+                    warnings.warn(
+                        f"Using nn.ModuleList or nn.ModuleDict with quantum gates may cause "
+                        f"issues with static mode and tq2qiskit conversion. Consider using "
+                        f"tq.QuantumModuleList or tq.QuantumModuleDict instead.",
+                        UserWarning,
+                        stacklevel=2
+                    )
             module.parent_graph = self.graph
             if not isinstance(module, tq.QuantumDevice):
                 module.static_on(is_graph_top=False)


### PR DESCRIPTION
## Summary
Added a `UserWarning` when `nn.ModuleList` or `nn.ModuleDict` is used instead of `tq.QuantumModuleList` or `tq.QuantumModuleDict` in quantum modules.

## Problem
When users use `nn.ModuleList` to contain quantum gates, `tq2qiskit` conversion fails because:
- `nn.ModuleList` doesn't have `static_on()` / `static_off()` methods
- `nn.ModuleList` doesn't have a `.graph` attribute for the flattening logic
- The recursive traversal in `build_flat_module_list()` can't handle regular containers

## Solution
Issue a warning during `static_on()` to help users understand the issue and guide them to use the correct container types.

```python
# Problematic:
self.gates = nn.ModuleList([tq.RX(), tq.RY()])

# Recommended:
self.gates = tq.QuantumModuleList([tq.RX(), tq.RY()])
```

## Test plan
- [x] Verify warning is issued when using nn.ModuleList
- [x] Verify no warning for tq.QuantumModuleList

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)