### PR TITLE
Fix NoiseDevice buffer device placement

### DIFF
--- a/torchquantum/device/noisedevices.py
+++ b/torchquantum/device/noisedevices.py
@@ -62,7 +62,7 @@ class NoiseDevice(nn.Module):
 
         _density = torch.zeros(2 ** (2 * self.n_wires), dtype=C_DTYPE)
         _density[0] = 1 + 0j
-        _density = torch.reshape(_density, [2] * (2 * self.n_wires))
+        _density = torch.reshape(_density, [2] * (2 * self.n_wires)).to(self.device)
         self._dims = 2 * self.n_wires
         self.register_buffer("density", _density)
 


### PR DESCRIPTION
## Summary
Added `.to(self.device)` when initializing the density tensor in `NoiseDevice` to match the behavior of `QuantumDevice`.

## Problem
`NoiseDevice` buffers remained on CPU even when `device='cuda'` was specified:

```python
# In NoiseDevice.__init__ (before fix):
_density = torch.zeros(2 ** (2 * self.n_wires), dtype=C_DTYPE)
_density[0] = 1 + 0j
_density = torch.reshape(_density, [2] * (2 * self.n_wires))  # NOT moved to device!

# In QuantumDevice.__init__ (correct behavior):
_state = torch.reshape(_state, [2] * self.n_wires).to(self.device)  # Moved to device
```

This caused:
- `model.load_state_dict()` to fail with device mismatch errors
- GPU-based noise simulations to fail unexpectedly
- State dicts saved from GPU models couldn't be loaded properly

## Solution
Added `.to(self.device)` to the density tensor initialization, consistent with `QuantumDevice`.

## Test plan
- [x] Verify NoiseDevice buffers are on correct device after initialization
- [ ] Test save/load with GPU models using NoiseDevice

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)