### PR TITLE
Add state validation to QuantumDevice.set_states()

### DIFF
--- a/torchquantum/device/devices.py
+++ b/torchquantum/device/devices.py
@@ -25,6 +25,7 @@ SOFTWARE.
 import torch
 import torch.nn as nn
 import numpy as np
+import warnings
 
 from torchquantum.macro import C_DTYPE
 from torchquantum.functional import func_name_dict, func_name_dict_collect
@@ -81,9 +82,43 @@ class QuantumDevice(nn.Module):
         """Clone the states of the quantum device."""
         self.states = existing_states.clone()
 
-    def set_states(self, states: torch.Tensor):
-        """Set the states of the quantum device. The states are represented"""
+    def set_states(self, states: torch.Tensor, check_legality: bool = False):
+        """Set the states of the quantum device.
+
+        Args:
+            states (torch.Tensor): The quantum states tensor with shape
+                (batch_size, 2**n_wires) or (batch_size, 2, 2, ..., 2).
+            check_legality (bool): If True, warns when batch size doesn't match
+                the device's bsz or when states are not normalized. Default False.
+
+        Note:
+            Setting states will update the device's internal batch size to match
+            the input states' batch size.
+        """
         bsz = states.shape[0]
+
+        if check_legality:
+            # Warn if batch size doesn't match
+            if bsz != self.bsz:
+                warnings.warn(
+                    f"Input states batch size ({bsz}) differs from device bsz ({self.bsz}). "
+                    f"Device bsz will be updated to {bsz}.",
+                    UserWarning,
+                    stacklevel=2
+                )
+
+            # Check normalization (sum of |amplitude|^2 should be ~1 for each state)
+            states_flat = states.reshape(bsz, -1)
+            norms = torch.sum(torch.abs(states_flat) ** 2, dim=1)
+            if not torch.allclose(norms, torch.ones_like(norms), atol=1e-5):
+                warnings.warn(
+                    f"Input states are not normalized. Norms: {norms.tolist()}. "
+                    f"Consider normalizing your states for valid quantum computations.",
+                    UserWarning,
+                    stacklevel=2
+                )
+
+        self.bsz = bsz
         self.states = torch.reshape(states, [bsz] + [2] * self.n_wires)
 
     def reset_states(self, bsz: int):


### PR DESCRIPTION
## Summary
Add optional `check_legality` parameter to `set_states()` that validates:
- Batch size consistency between input states and device
- State normalization (|amplitudes|² should sum to 1)

## Problem
As noted in #305, users can set states with mismatched batch sizes or unnormalized states without any warning, leading to confusion and incorrect results.

## Solution
Add opt-in validation with informative warnings:

```python
q_device = tq.QuantumDevice(n_wires=2, bsz=1)

# Without validation (default, backwards compatible)
q_device.set_states(states)

# With validation
q_device.set_states(states, check_legality=True)
# Warning: Input states batch size (3) differs from device bsz (1)...
# Warning: Input states are not normalized. Norms: [103.0]...
```

The device's `bsz` is updated to match the input states' batch size.

## Test plan
- [x] Verify warning is issued for mismatched batch size
- [x] Verify warning is issued for unnormalized states
- [x] Verify no warnings when check_legality=False (default)

Fixes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)