### PR TITLE
Fix batch size mismatch in clifford_qnn example

### DIFF
--- a/examples/clifford_qnn/mnist_clifford_qnn.py
+++ b/examples/clifford_qnn/mnist_clifford_qnn.py
@@ -55,6 +55,9 @@ class QFCModel(tq.QuantumModule):
         bsz = x.shape[0]
         x = F.avg_pool2d(x, 6).view(bsz, 16)
 
+        # Reset quantum device states for current batch size
+        self.q_device.reset_states(bsz)
+
         if use_qiskit:
             x = self.qiskit_processor.process_parameterized(
                 self.q_device, self.encoder, self.q_layer, self.measure, x


### PR DESCRIPTION
## Summary
- Add `reset_states(bsz)` call in `QFCModel.forward()` to ensure quantum device state dimensions match the current batch size
- The QuantumDevice is initialized with `bsz=1` by default, but during training the batch size varies
- Without resetting states, tensor dimension mismatch causes RuntimeError during matrix operations

## Root Cause
The `QuantumDevice` is created in `__init__` with default batch size 1:
```python
self.q_device = tq.QuantumDevice(n_wires=self.n_wires)  # bsz defaults to 1
```

But in `forward()`, the input batch size varies (256 for full batches, smaller for final batch). The quantum operations expect the device states to match the input batch size.

## Fix
Call `reset_states(bsz)` before using the quantum device:
```python
def forward(self, x, use_qiskit=False):
    bsz = x.shape[0]
    x = F.avg_pool2d(x, 6).view(bsz, 16)
    
    # Reset quantum device states for current batch size
    self.q_device.reset_states(bsz)
    
    # ... rest of forward
```

## Test plan
- [ ] Run `python examples/clifford_qnn/mnist_clifford_qnn.py` to verify no RuntimeError
- [ ] Verify training completes with varying batch sizes

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)