### PR TITLE
Use local h2_new.txt instead of Dropbox download

### DIFF
--- a/sec1_basic.ipynb
+++ b/sec1_basic.ipynb
@@ -19416,7 +19416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -19427,32 +19427,8 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--2025-04-29 21:10:15--  https://www.dropbox.com/s/1rtttfxoo02s09e/h2_new.txt\n",
-      "Resolving www.dropbox.com (www.dropbox.com)... 162.125.4.18, 2620:100:6019:18::a27d:412\n",
-      "Connecting to www.dropbox.com (www.dropbox.com)|162.125.4.18|:443... connected.\n",
-      "HTTP request sent, awaiting response... 302 Found\n",
-      "Location: https://www.dropbox.com/scl/fi/5hfv3opi7nb0toxzhohaz/h2_new.txt?rlkey=2r8t0enh6s8zsev5uj15qsy32 [following]\n",
-      "--2025-04-29 21:10:16--  https://www.dropbox.com/scl/fi/5hfv3opi7nb0toxzhohaz/h2_new.txt?rlkey=2r8t0enh6s8zsev5uj15qsy32\n",
-      "Reusing existing connection to www.dropbox.com:443.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: unspecified [text/html]\n",
-      "Saving to: ‘h2_new.txt’\n",
-      "\n",
-      "h2_new.txt              [ <=>                ] 155.39K  --.-KB/s    in 0.1s    \n",
-      "\n",
-      "2025-04-29 21:10:16 (1.04 MB/s) - ‘h2_new.txt’ saved [159124]\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "! wget https://www.dropbox.com/s/1rtttfxoo02s09e/h2_new.txt"
-   ]
+   "outputs": [],
+   "source": "# Copy h2_new.txt from the examples directory (no external download needed)\n# The file is already included in the torchquantum repository\nimport shutil\nshutil.copy('examples/vqe/h2_new.txt', 'h2_new.txt')\nprint(\"h2_new.txt copied from examples/vqe/\")"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- Replace the wget command in `sec1_basic.ipynb` that downloads `h2_new.txt` from Dropbox with a simple file copy from the repository's `examples/vqe/` directory
- The file is already included in the repository, eliminating the need for external downloads

## Problem
The notebook cell that downloads `h2_new.txt` from Dropbox:
```bash
! wget https://www.dropbox.com/s/1rtttfxoo02s09e/h2_new.txt
```

This fails because:
- The Dropbox link may become unavailable
- It may require authentication
- External dependencies make the notebook less reliable

## Solution
Copy from the local repository instead:
```python
import shutil
shutil.copy('examples/vqe/h2_new.txt', 'h2_new.txt')
```

## Test plan
- [ ] Run the VQE section of sec1_basic.ipynb
- [ ] Verify h2_new.txt is correctly copied and parsed

Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)