### PR TITLE
Fix TypeError when converting Qiskit circuits with ParameterExpression

### DIFF
--- a/torchquantum/plugin/qiskit/qiskit_plugin.py
+++ b/torchquantum/plugin/qiskit/qiskit_plugin.py
@@ -64,6 +64,30 @@ __all__ = [
 ]
 
 
+def _get_param_value(param):
+    """Convert a parameter value to float, handling ParameterExpression properly.
+
+    Args:
+        param: A parameter value, possibly a qiskit.circuit.ParameterExpression.
+
+    Returns:
+        float: The numeric value of the parameter.
+
+    Raises:
+        TypeError: If the ParameterExpression has unbound parameters.
+    """
+    from qiskit.circuit import ParameterExpression
+
+    if isinstance(param, ParameterExpression):
+        if param.is_parameterized():
+            raise TypeError(
+                f"ParameterExpression with unbound parameters "
+                f"({param.parameters}) cannot be cast to a float."
+            )
+        return float(param)
+    return float(param)
+
+
 def qiskit2tq_op_history(circ):
     if getattr(circ, "_layout", None) is not None:
         try:
@@ -88,7 +112,9 @@ def qiskit2tq_op_history(circ):
         wires = [p2v[wire] for wire in wires]
         # sometimes the gate.params is ParameterExpression class
         init_params = (
-            list(map(float, gate.operation.params)) if len(gate.operation.params) > 0 else None
+            [_get_param_value(p) for p in gate.operation.params]
+            if len(gate.operation.params) > 0
+            else None
         )
         print(op_name,)
 
@@ -850,7 +876,9 @@ def qiskit2tq_Operator(circ: QuantumCircuit):
         wires = [p2v[wire] for wire in wires]
         # sometimes the gate.params is ParameterExpression class
         init_params = (
-            list(map(float, gate.operation.params)) if len(gate.operation.params) > 0 else None
+            [_get_param_value(p) for p in gate.operation.params]
+            if len(gate.operation.params) > 0
+            else None
         )
 
         if op_name in [


### PR DESCRIPTION
Good day

## Issue
Fixes mit-han-lab/torchquantum#198

## Problem
When using the Qiskit plugin to convert a Qiskit circuit containing a  (unbound parameters), the conversion would fail with a  because Python's built-in  cannot handle unbound Qiskit  objects.

The error occurred in two functions:
- 
- 

Both used  which fails when params contain unbound  objects.

## Solution
Added a helper function  that properly handles  objects:
1. Checks if the parameter is a  using 
2. If it is parameterized (unbound), raises a descriptive 
3. If bound, converts to float using 
4. For non- values, simply calls 

This provides a clear error message rather than a confusing 

## Changes
- :
  - Added  helper function
  - Updated  to use the helper
  - Updated  to use the helper

## Testing
- Logic tested with mock  objects
- Unbound parameters now raise a descriptive error
- Bound parameters and plain floats are converted correctly

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof